### PR TITLE
Exception handling

### DIFF
--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/GrpcBinder.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/GrpcBinder.kt
@@ -1,5 +1,6 @@
 package com.sourceforgery.tachikoma
 
+import com.sourceforgery.tachikoma.grpc.catcher.GrpcExceptionMap
 import com.sourceforgery.tachikoma.maildelivery.impl.MailDeliveryService
 import com.sourceforgery.tachikoma.mta.MTADeliveryService
 import com.sourceforgery.tachikoma.mta.MTAEmailQueueService
@@ -23,6 +24,9 @@ class GrpcBinder : AbstractBinder() {
                 .`in`(Singleton::class.java)
         bindAsContract(MailDeliveryService::class.java)
                 .to(BindableService::class.java)
+                .`in`(Singleton::class.java)
+
+        bindAsContract(GrpcExceptionMap::class.java)
                 .`in`(Singleton::class.java)
 
         bindAsContract(TrackingDecoderImpl::class.java)

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/grpc/catcher/GrpcExceptionCatcher.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/grpc/catcher/GrpcExceptionCatcher.kt
@@ -1,0 +1,31 @@
+package com.sourceforgery.tachikoma.grpc.catcher
+
+import com.sourceforgery.tachikoma.config.DebugConfig
+import io.grpc.Metadata
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import java.io.PrintWriter
+import java.io.StringWriter
+
+abstract class GrpcExceptionCatcher<in T : Throwable>(
+        val debugConfig: DebugConfig
+) {
+    abstract fun status(t: T): Status
+
+    open fun metadata(t: T) = Metadata()
+
+    open fun throwIt(t: T): Nothing {
+        throw StatusRuntimeException(status(t), metadata(t))
+    }
+
+    protected fun stackToString(e: Throwable): String {
+        if (debugConfig.sendDebugData) {
+            StringWriter().use {
+                e.printStackTrace(PrintWriter(it))
+                return it.toString()
+            }
+        } else {
+            return ""
+        }
+    }
+}

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/grpc/catcher/GrpcExceptionMap.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/grpc/catcher/GrpcExceptionMap.kt
@@ -3,6 +3,8 @@ package com.sourceforgery.tachikoma.grpc.catcher
 import com.sourceforgery.tachikoma.config.DebugConfig
 import io.grpc.Status
 import org.glassfish.hk2.api.IterableProvider
+import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Type
 import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 
@@ -11,23 +13,29 @@ class GrpcExceptionMap
 private constructor(
         private val catchers: IterableProvider<GrpcExceptionCatcher<Throwable>>,
         private val debugConfig: DebugConfig
-) : ConcurrentHashMap<Class<Throwable>, GrpcExceptionCatcher<Throwable>>() {
+) {
+    private val map = ConcurrentHashMap<Class<Throwable>, GrpcExceptionCatcher<Throwable>>()
 
     private val defaultCatcher = object : GrpcExceptionCatcher<Throwable>(debugConfig) {
         override fun status(t: Throwable) = Status.fromThrowable(t).withDescription(stackToString(t))
     }
 
-    override operator fun get(key: Class<Throwable>): GrpcExceptionCatcher<Throwable> {
-        return super.computeIfAbsent(key, { findClass(key) })
+    fun findCatcher(key: Throwable): GrpcExceptionCatcher<Throwable> {
+        @Suppress("UNCHECKED_CAST")
+        val clazz = key::class.java as Class<Throwable>
+        return map.computeIfAbsent(clazz, { findClass(clazz) })
+    }
+
+    private fun getGenerics(catcher: GrpcExceptionCatcher<*>): Type {
+        return (catcher.javaClass.genericSuperclass.javaClass as ParameterizedType).actualTypeArguments[0]
     }
 
     private fun findClass(key: Class<Throwable>): GrpcExceptionCatcher<Throwable> {
         var clazz: Class<*> = key
         while (clazz != Object::class.java) {
-            catchers.firstOrNull { it == clazz }
+            catchers.firstOrNull { getGenerics(it) == clazz }
                     ?.let {
-                        put(key, it)
-                        it
+                        return it
                     }
             clazz = clazz.superclass
         }

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/grpc/catcher/GrpcExceptionMap.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/grpc/catcher/GrpcExceptionMap.kt
@@ -41,5 +41,4 @@ private constructor(
         }
         return defaultCatcher
     }
-
 }

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/grpc/catcher/GrpcExceptionMap.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/grpc/catcher/GrpcExceptionMap.kt
@@ -1,0 +1,37 @@
+package com.sourceforgery.tachikoma.grpc.catcher
+
+import com.sourceforgery.tachikoma.config.DebugConfig
+import io.grpc.Status
+import org.glassfish.hk2.api.IterableProvider
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+class GrpcExceptionMap
+@Inject
+private constructor(
+        private val catchers: IterableProvider<GrpcExceptionCatcher<Throwable>>,
+        private val debugConfig: DebugConfig
+) : ConcurrentHashMap<Class<Throwable>, GrpcExceptionCatcher<Throwable>>() {
+
+    private val defaultCatcher = object : GrpcExceptionCatcher<Throwable>(debugConfig) {
+        override fun status(t: Throwable) = Status.fromThrowable(t).withDescription(stackToString(t))
+    }
+
+    override operator fun get(key: Class<Throwable>): GrpcExceptionCatcher<Throwable> {
+        return super.computeIfAbsent(key, { findClass(key) })
+    }
+
+    private fun findClass(key: Class<Throwable>): GrpcExceptionCatcher<Throwable> {
+        var clazz: Class<*> = key
+        while (clazz != Object::class.java) {
+            catchers.firstOrNull { it == clazz }
+                    ?.let {
+                        put(key, it)
+                        it
+                    }
+            clazz = clazz.superclass
+        }
+        return defaultCatcher
+    }
+
+}

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/MailDeliveryService.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/MailDeliveryService.kt
@@ -34,7 +34,6 @@ import org.jsoup.nodes.Element
 import java.io.ByteArrayOutputStream
 import java.io.StringReader
 import java.io.StringWriter
-import java.lang.RuntimeException
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.time.Instant
@@ -100,8 +99,7 @@ private constructor(
                                 .build()
                 )
             }
-            throw RuntimeException("TEST")
-//            responseObserver.onCompleted()
+            responseObserver.onCompleted()
         }
     }
 

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/MailDeliveryService.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/MailDeliveryService.kt
@@ -34,6 +34,7 @@ import org.jsoup.nodes.Element
 import java.io.ByteArrayOutputStream
 import java.io.StringReader
 import java.io.StringWriter
+import java.lang.RuntimeException
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.time.Instant
@@ -99,7 +100,8 @@ private constructor(
                                 .build()
                 )
             }
-            responseObserver.onCompleted()
+            throw RuntimeException("TEST")
+//            responseObserver.onCompleted()
         }
     }
 

--- a/tachikoma-internal-api/src/main/kotlin/com/sourceforgery/tachikoma/config/DebugConfig.kt
+++ b/tachikoma-internal-api/src/main/kotlin/com/sourceforgery/tachikoma/config/DebugConfig.kt
@@ -1,0 +1,5 @@
+package com.sourceforgery.tachikoma.config
+
+interface DebugConfig {
+    val sendDebugData: Boolean
+}

--- a/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/RestBinder.kt
+++ b/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/RestBinder.kt
@@ -1,5 +1,9 @@
 package com.sourceforgery.rest
 
+import com.linecorp.armeria.common.HttpRequest
+import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.common.RequestContext
+import com.sourceforgery.rest.catchers.RestExceptionCatcher
 import com.sourceforgery.rest.catchers.RestExceptionMap
 import com.sourceforgery.rest.tracking.TrackingRest
 import org.glassfish.hk2.utilities.binding.AbstractBinder

--- a/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/RestBinder.kt
+++ b/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/RestBinder.kt
@@ -1,5 +1,6 @@
 package com.sourceforgery.rest
 
+import com.sourceforgery.rest.catchers.RestExceptionMap
 import com.sourceforgery.rest.tracking.TrackingRest
 import org.glassfish.hk2.utilities.binding.AbstractBinder
 import javax.inject.Singleton
@@ -9,5 +10,8 @@ class RestBinder : AbstractBinder() {
         bindAsContract(TrackingRest::class.java)
                 .to(RestService::class.java)
                 .`in`(Singleton::class.java)
+        bindAsContract(RestExceptionMap::class.java)
+                .`in`(Singleton::class.java
+                )
     }
 }

--- a/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/RestBinder.kt
+++ b/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/RestBinder.kt
@@ -1,9 +1,5 @@
 package com.sourceforgery.rest
 
-import com.linecorp.armeria.common.HttpRequest
-import com.linecorp.armeria.common.HttpResponse
-import com.linecorp.armeria.common.RequestContext
-import com.sourceforgery.rest.catchers.RestExceptionCatcher
 import com.sourceforgery.rest.catchers.RestExceptionMap
 import com.sourceforgery.rest.tracking.TrackingRest
 import org.glassfish.hk2.utilities.binding.AbstractBinder

--- a/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/catchers/RestExceptionCatcher.kt
+++ b/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/catchers/RestExceptionCatcher.kt
@@ -1,0 +1,9 @@
+package com.sourceforgery.rest.catchers
+
+import com.linecorp.armeria.common.HttpRequest
+import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.common.RequestContext
+
+interface RestExceptionCatcher<T : Throwable> {
+    fun handleException(ctx: RequestContext?, req: HttpRequest?, cause: T): HttpResponse
+}

--- a/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/catchers/RestExceptionMap.kt
+++ b/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/catchers/RestExceptionMap.kt
@@ -1,0 +1,64 @@
+package com.sourceforgery.rest.catchers
+
+import com.linecorp.armeria.common.HttpRequest
+import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.common.HttpStatus
+import com.linecorp.armeria.common.MediaType
+import com.linecorp.armeria.common.RequestContext
+import com.sourceforgery.tachikoma.config.DebugConfig
+import com.sourceforgery.tachikoma.logging.logger
+import org.glassfish.hk2.api.IterableProvider
+import java.io.PrintWriter
+import java.io.StringWriter
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+
+class RestExceptionMap
+@Inject
+private constructor(
+        private val catchers: IterableProvider<RestExceptionCatcher<Throwable>>,
+        private val debugConfig: DebugConfig
+) : ConcurrentHashMap<Class<Throwable>, RestExceptionCatcher<Throwable>>() {
+
+    private val defaultCatcher = object : RestExceptionCatcher<Throwable> {
+        override fun handleException(ctx: RequestContext?, req: HttpRequest?, cause: Throwable): HttpResponse {
+            return if (debugConfig.sendDebugData) {
+                HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR, MediaType.PLAIN_TEXT_UTF_8, stackToString(cause))
+            } else {
+                HttpResponse.of(HttpStatus.INTERNAL_SERVER_ERROR)
+            }
+        }
+    }
+
+    private fun stackToString(e: Throwable): String {
+        if (debugConfig.sendDebugData) {
+            StringWriter().use {
+                e.printStackTrace(PrintWriter(it))
+                return it.toString()
+            }
+        } else {
+            return ""
+        }
+    }
+
+    override operator fun get(key: Class<Throwable>): RestExceptionCatcher<Throwable> {
+        return super.computeIfAbsent(key, { findClass(key) })
+    }
+
+    private fun findClass(key: Class<Throwable>): RestExceptionCatcher<Throwable> {
+        var clazz: Class<*> = key
+        while (clazz != Object::class.java) {
+            catchers.firstOrNull { it == clazz }
+                    ?.let {
+                        put(key, it)
+                        it
+                    }
+            clazz = clazz.superclass
+        }
+        return defaultCatcher
+    }
+
+    companion object {
+        private val LOGGER = logger()
+    }
+}

--- a/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/tracking/TrackingRest.kt
+++ b/tachikoma-rest/src/main/kotlin/com/sourceforgery/rest/tracking/TrackingRest.kt
@@ -30,7 +30,6 @@ private constructor(
             val trackingData = trackingDecoder.decodeTrackingData(trackingDataString)
             // TODO Do tracking stuff here, possibly in another thread
         } catch (e: Exception) {
-            e.printStackTrace()
             LOGGER.warn { "Failed to track invalid link $trackingDataString with error ${e.message}" }
             LOGGER.debug(e, { "Failed to track invalid link $trackingDataString" })
         }
@@ -40,6 +39,7 @@ private constructor(
     @Get("regex:^/t/(?<trackingData>.*)")
     @ProduceType("text/html")
     fun trackClick(@Param("trackingData") trackingDataString: String): HttpResponse {
+        throw RuntimeException()
         try {
             val trackingData = trackingDecoder.decodeTrackingData(trackingDataString)
 

--- a/tachikoma-startup/src/main/kotlin/com/sourceforgery/tachikoma/config/Configuration.kt
+++ b/tachikoma-startup/src/main/kotlin/com/sourceforgery/tachikoma/config/Configuration.kt
@@ -5,9 +5,10 @@ import com.sourceforgery.tachikoma.tracking.TrackingConfig
 import java.net.URI
 import java.nio.charset.StandardCharsets
 
-internal class Configuration : DatabaseConfig, TrackingConfig, MqConfig, WebServerConfig {
+internal class Configuration : DatabaseConfig, TrackingConfig, MqConfig, WebServerConfig, DebugConfig {
     override val databaseEncryptionKey: String = readConfig("DATABASE_ENCRYPTION_KEY", "aigac4eeth4uChosea2ohvazoop3Ootal6Vaethei2ohhibooK")
     override val mqUrl: URI = readConfig("MQ_URL", "amqp://guest:guest@localhost/tachikoma", URI::class.java)
+    override val sendDebugData: Boolean = readConfig("SEND_DEBUG_DATA", true)
     override val sqlUrl = readConfig("SQL_URL", "postgres://username:password@localhost:5432/tachikoma", URI::class.java)
     override val timeDatabaseQueries: Boolean = readConfig("TIME_DATABASE_QUERIES", true)
     override val trackingEncryptionKey: String = readConfig("TRACKING_ENCRYPTION_KEY", "peilieK6RoomaiPhainocool6ebezai0ox7qui4p")

--- a/tachikoma-startup/src/main/kotlin/com/sourceforgery/tachikoma/startup/StartupBinder.kt
+++ b/tachikoma-startup/src/main/kotlin/com/sourceforgery/tachikoma/startup/StartupBinder.kt
@@ -2,6 +2,7 @@ package com.sourceforgery.tachikoma.startup
 
 import com.sourceforgery.tachikoma.config.Configuration
 import com.sourceforgery.tachikoma.config.DatabaseConfig
+import com.sourceforgery.tachikoma.config.DebugConfig
 import com.sourceforgery.tachikoma.config.WebServerConfig
 import com.sourceforgery.tachikoma.mq.MqConfig
 import com.sourceforgery.tachikoma.tracking.TrackingConfig
@@ -15,6 +16,7 @@ class StartupBinder : AbstractBinder() {
                 .to(TrackingConfig::class.java)
                 .to(MqConfig::class.java)
                 .to(WebServerConfig::class.java)
+                .to(DebugConfig::class.java)
                 .`in`(Singleton::class.java)
     }
 }

--- a/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/Main.kt
+++ b/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/Main.kt
@@ -57,7 +57,6 @@ fun main(vararg args: String) {
             .allowRequestMethods(HttpMethod.GET)
             .build(object : HttpHealthCheckService() {})!!
 
-
     // Order matters!
     val serverBuilder = ServerBuilder()
             .serviceUnder("/health", healthService)

--- a/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/grpc/GrpcExceptionInterceptor.kt
+++ b/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/grpc/GrpcExceptionInterceptor.kt
@@ -36,7 +36,8 @@ private constructor(
             }
 
             private fun rethrowAsStatusException(e: Exception): Nothing {
-                grpcExceptionCatchers[e::class.java as Class<*>]!!.throwIt(e)
+                grpcExceptionCatchers.findCatcher(e)
+                        .throwIt(e)
             }
         }
     }

--- a/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/grpc/GrpcExceptionInterceptor.kt
+++ b/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/grpc/GrpcExceptionInterceptor.kt
@@ -1,0 +1,47 @@
+package com.sourceforgery.tachikoma.webserver.grpc
+
+import com.sourceforgery.tachikoma.grpc.catcher.GrpcExceptionMap
+import com.sourceforgery.tachikoma.logging.logger
+import io.grpc.ForwardingServerCallListener
+import io.grpc.Metadata
+import io.grpc.ServerCall
+import io.grpc.ServerCallHandler
+import io.grpc.ServerInterceptor
+import javax.inject.Inject
+
+internal class GrpcExceptionInterceptor
+@Inject
+private constructor(
+        private val grpcExceptionCatchers: GrpcExceptionMap
+) : ServerInterceptor {
+    override fun <ReqT, RespT> interceptCall(call: ServerCall<ReqT, RespT>, headers: Metadata, next: ServerCallHandler<ReqT, RespT>): ServerCall.Listener<ReqT> {
+        val nextCall = next.startCall(call, headers)
+        return object : ForwardingServerCallListener.SimpleForwardingServerCallListener<ReqT>(nextCall) {
+            override fun onHalfClose() {
+                try {
+                    super.onHalfClose()
+                } catch (e: Exception) {
+                    LOGGER.warn("Exception in gRPC", e)
+                    rethrowAsStatusException(e)
+                }
+            }
+
+            override fun onMessage(message: ReqT) {
+                try {
+                    super.onMessage(message)
+                } catch (e: Exception) {
+                    LOGGER.warn("Exception in gRPC", e)
+                    rethrowAsStatusException(e)
+                }
+            }
+
+            private fun rethrowAsStatusException(e: Exception): Nothing {
+                grpcExceptionCatchers[e::class.java as Class<*>]!!.throwIt(e)
+            }
+        }
+    }
+
+    companion object {
+        val LOGGER = logger()
+    }
+}

--- a/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/grpc/HttpRequestScopedDecorator.kt
+++ b/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/grpc/HttpRequestScopedDecorator.kt
@@ -1,0 +1,53 @@
+package com.sourceforgery.tachikoma.webserver.grpc
+
+import com.linecorp.armeria.common.HttpRequest
+import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.common.RequestContext
+import com.linecorp.armeria.common.logging.RequestLogAvailability
+import com.linecorp.armeria.server.DecoratingServiceFunction
+import com.linecorp.armeria.server.Service
+import com.linecorp.armeria.server.ServiceRequestContext
+import com.sourceforgery.tachikoma.hk2.HK2RequestContextImpl
+import com.sourceforgery.tachikoma.hk2.SettableReference
+import com.sourceforgery.tachikoma.webserver.hk2.HTTP_REQUEST_TYPE
+import com.sourceforgery.tachikoma.webserver.hk2.REQUEST_CONTEXT_TYPE
+import io.netty.util.AttributeKey
+import org.glassfish.hk2.api.ServiceLocator
+import java.util.function.Consumer
+import javax.inject.Inject
+
+class HttpRequestScopedDecorator
+@Inject
+private constructor(
+        private val hK2RequestContext: HK2RequestContextImpl,
+        private val serviceLocator: ServiceLocator
+) : DecoratingServiceFunction<HttpRequest, HttpResponse> {
+    override fun serve(delegate: Service<HttpRequest, HttpResponse>, ctx: ServiceRequestContext, req: HttpRequest): HttpResponse {
+        val oldHk2Ctx = hK2RequestContext.retrieveCurrent()
+        ctx.attr(OLD_HK2_CONTEXT_KEY).set(oldHk2Ctx)
+        val hk2Ctx = hK2RequestContext.createInstance()
+        ctx.attr(HK2_CONTEXT_KEY).set(hk2Ctx)
+        ctx.onEnter(Consumer {
+            hK2RequestContext.setCurrent(hk2Ctx)
+        })
+        ctx.onExit(Consumer {
+            hK2RequestContext.resumeCurrent(oldHk2Ctx)
+        })
+        ctx.log().addListener({ hK2RequestContext.release(hk2Ctx) }, RequestLogAvailability.COMPLETE)
+        return hK2RequestContext.runInScope(hk2Ctx,
+                {
+                    serviceLocator
+                            .getService<SettableReference<HttpRequest>>(HTTP_REQUEST_TYPE)
+                            .value = req
+                    serviceLocator
+                            .getService<SettableReference<RequestContext>>(REQUEST_CONTEXT_TYPE)
+                            .value = ctx
+                    delegate.serve(ctx, req)
+                })
+    }
+
+    companion object {
+        private val HK2_CONTEXT_KEY = AttributeKey.valueOf<HK2RequestContextImpl.Instance>("HK2_CONTEXT")
+        private val OLD_HK2_CONTEXT_KEY = AttributeKey.valueOf<HK2RequestContextImpl.Instance>("OLD_HK2_CONTEXT")
+    }
+}

--- a/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/hk2/WebBinder.kt
+++ b/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/hk2/WebBinder.kt
@@ -9,6 +9,9 @@ import com.sourceforgery.tachikoma.hk2.HK2RequestContextImpl
 import com.sourceforgery.tachikoma.hk2.ReferencingFactory
 import com.sourceforgery.tachikoma.hk2.RequestScoped
 import com.sourceforgery.tachikoma.webserver.AuthenticationFactory
+import com.sourceforgery.tachikoma.webserver.grpc.GrpcExceptionInterceptor
+import com.sourceforgery.tachikoma.webserver.grpc.HttpRequestScopedDecorator
+import com.sourceforgery.tachikoma.webserver.rest.RestExceptionHandlerFunction
 import org.glassfish.hk2.api.Context
 import org.glassfish.hk2.api.TypeLiteral
 import org.glassfish.hk2.utilities.binding.AbstractBinder
@@ -38,6 +41,14 @@ class WebBinder : AbstractBinder() {
                 .to(HK2RequestContext::class.java)
                 .to(RequestScoped::class.java)
                 .to(object : TypeLiteral<Context<RequestScoped>>() {}.type)
+                .`in`(Singleton::class.java)
+        bindAsContract(HttpRequestScopedDecorator::class.java)
+                .`in`(Singleton::class.java)
+
+        bindAsContract(GrpcExceptionInterceptor::class.java)
+                .`in`(Singleton::class.java)
+
+        bindAsContract(RestExceptionHandlerFunction::class.java)
                 .`in`(Singleton::class.java)
     }
 }

--- a/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/rest/RestExceptionHandlerFunction.kt
+++ b/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/rest/RestExceptionHandlerFunction.kt
@@ -1,0 +1,18 @@
+package com.sourceforgery.tachikoma.webserver.rest
+
+import com.linecorp.armeria.common.HttpRequest
+import com.linecorp.armeria.common.HttpResponse
+import com.linecorp.armeria.common.RequestContext
+import com.linecorp.armeria.server.annotation.ExceptionHandlerFunction
+import com.sourceforgery.rest.catchers.RestExceptionMap
+import javax.inject.Inject
+
+class RestExceptionHandlerFunction
+@Inject
+private constructor(
+        private val restExceptionMap: RestExceptionMap
+) : ExceptionHandlerFunction {
+    override fun handleException(ctx: RequestContext?, req: HttpRequest?, cause: Throwable): HttpResponse {
+        return restExceptionMap[cause::class.java]!!.handleException(ctx, req, cause)
+    }
+}

--- a/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/rest/RestExceptionHandlerFunction.kt
+++ b/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/rest/RestExceptionHandlerFunction.kt
@@ -13,6 +13,7 @@ private constructor(
         private val restExceptionMap: RestExceptionMap
 ) : ExceptionHandlerFunction {
     override fun handleException(ctx: RequestContext?, req: HttpRequest?, cause: Throwable): HttpResponse {
-        return restExceptionMap[cause::class.java]!!.handleException(ctx, req, cause)
+        @Suppress("UNCHECKED_CAST")
+        return restExceptionMap.findCatcher(cause::class.java as Class<Throwable>).handleException(ctx, req, cause)
     }
 }


### PR DESCRIPTION
Will close #31 and close #39 

Two different exception catchers. 
* gRPC which must extend GrpcExceptionCatcher 
* REST which must implement RestExceptionCatcher

Recommended way of implementing one is 
```kotlin
class FooExceptionCatcher : GrpcExceptionCatcher<Foo>(), RestExceptionCatcher<Foo> {
 // implement methods
}
```

and bind with
```kotlin
        bindAsContract(FooExceptionCatcher::class.java)
                .to(GrpcExceptionCatcher::class.java)
                .to(RestExceptionCatcher::class.java)
                .`in`(Singleton::class.java)
```