### PR TITLE
Fix generated pom in bintray release

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,5 @@
+rootProject.name='com.sourceforgery.tachikoma'
+
 include 'tachikoma-protobuf-annotations'
 
 include 'tachikoma-backend-api-proto'


### PR DESCRIPTION
Previously the pom had 'tachikoma' as the groupId of
project dependencies