### PR TITLE
Read/write HK2RequestContext directly from ServiceRequestContext when…

### DIFF
--- a/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/hk2/HK2RequestContextImpl.kt
+++ b/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/hk2/HK2RequestContextImpl.kt
@@ -3,6 +3,8 @@ package com.sourceforgery.tachikoma.hk2
 import com.google.common.base.MoreObjects
 import com.google.common.base.Preconditions.checkState
 import com.google.common.collect.Sets
+import com.linecorp.armeria.server.ServiceRequestContext
+import io.netty.util.AttributeKey
 import java.util.HashMap
 import java.util.UUID
 import javax.inject.Inject
@@ -18,7 +20,7 @@ private constructor(
     private val serviceLocator: ServiceLocator
 ) : Context<RequestScoped>, HK2RequestContext {
 
-    private val currentScopeInstance = ThreadLocal<Instance>()
+    private val threadLocalScopeInstance = ThreadLocal<Instance>()
     @Volatile
     private var isActive = true
 
@@ -63,25 +65,45 @@ private constructor(
 
     private fun current(): Instance {
         checkState(isActive, "Request scope has been already shut down.")
+        val armeriaCtx = ServiceRequestContext.currentOrNull()
+        val scopeInstance = if (armeriaCtx == null) {
+            threadLocalScopeInstance.get()
+        } else {
+            armeriaCtx.attr(HK2_CONTEXT_KEY).get()
+        }
 
-        val scopeInstance = currentScopeInstance.get()
         checkState(scopeInstance != null, "Not inside a request scope.")
 
         return scopeInstance!!
     }
 
-    internal fun retrieveCurrent(): Instance? {
+    private fun retrieveCurrent(): Instance? {
         checkState(isActive, "Request scope has been already shut down.")
-        return currentScopeInstance.get()
+        val armeriaCtx = ServiceRequestContext.currentOrNull()
+        return if (armeriaCtx == null) {
+            threadLocalScopeInstance.get()
+        } else {
+            armeriaCtx.attr(HK2_CONTEXT_KEY).get()
+        }
     }
 
-    internal fun setCurrent(instance: Instance) {
+    private fun setCurrent(instance: Instance) {
         checkState(isActive, "Request scope has been already shut down.")
-        currentScopeInstance.set(instance)
+        val armeriaCtx = ServiceRequestContext.currentOrNull()
+        if (armeriaCtx == null) {
+            threadLocalScopeInstance.set(instance)
+        } else {
+            armeriaCtx.attr(HK2_CONTEXT_KEY).set(instance)
+        }
     }
 
-    internal fun resumeCurrent(instance: Instance?) {
-        currentScopeInstance.set(instance)
+    private fun resumeCurrent(instance: Instance?) {
+        val armeriaCtx = ServiceRequestContext.currentOrNull()
+        if (armeriaCtx == null) {
+            threadLocalScopeInstance.set(instance)
+        } else {
+            armeriaCtx.attr(HK2_CONTEXT_KEY).set(instance)
+        }
     }
 
     internal fun createInstance(): Instance {
@@ -171,5 +193,6 @@ private constructor(
 
     companion object {
         val LOGGER = logger()
+        private val HK2_CONTEXT_KEY = AttributeKey.valueOf<HK2RequestContextImpl.Instance>("HK2_CONTEXT")
     }
 }

--- a/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/grpc/HttpRequestScopedDecorator.kt
+++ b/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/grpc/HttpRequestScopedDecorator.kt
@@ -23,16 +23,7 @@ private constructor(
     private val serviceLocator: ServiceLocator
 ) : DecoratingHttpServiceFunction {
     override fun serve(delegate: HttpService, ctx: ServiceRequestContext, req: HttpRequest): HttpResponse {
-        val oldHk2Ctx = hK2RequestContext.retrieveCurrent()
-        ctx.attr(OLD_HK2_CONTEXT_KEY).set(oldHk2Ctx)
         val hk2Ctx = hK2RequestContext.createInstance()
-        ctx.attr(HK2_CONTEXT_KEY).set(hk2Ctx)
-        ctx.onEnter(Consumer {
-            hK2RequestContext.setCurrent(hk2Ctx)
-        })
-        ctx.onExit(Consumer {
-            hK2RequestContext.resumeCurrent(oldHk2Ctx)
-        })
         ctx.log().addListener({ hK2RequestContext.release(hk2Ctx) }, RequestLogAvailability.COMPLETE)
         return hK2RequestContext.runInScope(hk2Ctx
         ) {
@@ -44,10 +35,5 @@ private constructor(
                 .value = ctx
             delegate.serve(ctx, req)
         }
-    }
-
-    companion object {
-        private val HK2_CONTEXT_KEY = AttributeKey.valueOf<HK2RequestContextImpl.Instance>("HK2_CONTEXT")
-        private val OLD_HK2_CONTEXT_KEY = AttributeKey.valueOf<HK2RequestContextImpl.Instance>("OLD_HK2_CONTEXT")
     }
 }


### PR DESCRIPTION
… possible instead of keeping two threadlocals in sync.

In https://github.com/line/armeria/pull/2375 we are considering removing `onEnter` and `onExit` on request context, as we find usually there are better patterns.

For context in different library, we find that it's better to use `RequestContext` itself as the thread-local for scopes instead of a separate one that is synced.

We use this pattern for integrating with brave, which also has context

https://github.com/line/armeria/blob/master/brave/src/main/java/com/linecorp/armeria/common/brave/RequestContextCurrentTraceContext.java#L49

This version of the PR does still fallback to a `ThreadLocal` when there isn't any `ServiceRequestContext` available. If your server happens to have the property that all business logic will have it available, we could remove the fallback.

I believe a bug is fixed with this approach where OLD_HK2_CONTEXT_KEY is only set once, whereas I believe it's supposed to be set on `onEnter` too. This sort of cludge is why we don't like `onEnter` much anymore :)

Feel free to use this PR, or close it if a different approach might be better. Or comment on the attached PR why `onEnter/onExit` are must-have for armeria 1.0.

I haven't been able to confirm if this PR even works, `./gradlew test` for me has issues with the grpc generated code for some reason :( So it will be hard for me to iterate on this PR if required.

```
[17:20] (master●) Anuraag:~/git/tachikoma % ./gradlew test
Starting a Gradle Daemon, 1 busy and 5 incompatible Daemons could not be reused, use --status for details

> Task :tachikoma-frontend-api-proto:tachikoma-frontend-api-jvm:compileJava
C:\tools\msys64\home\Anuraag\git\tachikoma\tachikoma-frontend-api-proto\tachikoma-frontend-api-jvm\build\generated\source\proto\main\java\com\sourceforgery\tachikoma\grpc\frontend\blockedemail\BlockedEmail.java:6: error: class Blockedemail is public, should be declared in a file named Blockedemail.java
public final class Blockedemail {
             ^
C:\tools\msys64\home\Anuraag\git\tachikoma\tachikoma-frontend-api-proto\tachikoma-frontend-api-jvm\build\generated\source\proto\main\java\com\sourceforgery\tachikoma\grpc\frontend\incomingemailaddress\IncomingEmailAddress.java:6: error: class Incomingemailaddress is public, should be declared in a file named Incomingemailaddress.java
public final class Incomingemailaddress {
             ^
C:\tools\msys64\home\Anuraag\git\tachikoma\tachikoma-frontend-api-proto\tachikoma-frontend-api-jvm\build\generated\source\proto\main\java\com\sourceforgery\tachikoma\grpc\frontend\unsubscribe\UnsubscribeData.java:6: error: class Unsubscribedata is public, should be declared in a file named Unsubscribedata.java
public final class Unsubscribedata {
```