### PR TITLE
Fix HK2 Request Context so that queue-jobs works again

### DIFF
--- a/tachikoma-internal-api/src/main/kotlin/com/sourceforgery/tachikoma/hk2/HK2RequestContext.kt
+++ b/tachikoma-internal-api/src/main/kotlin/com/sourceforgery/tachikoma/hk2/HK2RequestContext.kt
@@ -8,6 +8,8 @@ interface HK2RequestContext {
     fun getContextInstance(): ReqCtxInstance
     fun <T> runInScope(ctx: ReqCtxInstance, task: (ServiceLocator) -> T): T
     fun createInArmeriaContext(serviceRequestContext: ServiceRequestContext): ReqCtxInstance
+    fun createInstance(): ReqCtxInstance
+    fun release(ctx: ReqCtxInstance)
 }
 
 interface ReqCtxInstance

--- a/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/TestHK2RequestContext.kt
+++ b/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/TestHK2RequestContext.kt
@@ -22,4 +22,6 @@ private constructor(
     }
 
     override fun createInArmeriaContext(serviceRequestContext: ServiceRequestContext) = TODO("not implemented")
+    override fun createInstance() = TODO("not implemented")
+    override fun release(ctx: ReqCtxInstance) = TODO("not implemented")
 }


### PR DESCRIPTION
The scope will terminate(and be released) before the queue processes the messages. This will make the handling of the scope more manual and thus only closed when the queueListener terminates

fixes https://github.com/SourceForgery/tachikoma/issues/196