### PR TITLE
Feature/ability to override message id domain

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,3 +2,4 @@ kotlin.incremental.usePreciseJavaTracking=true
 org.gradle.caching=true
 version=1.0.71-SNAPSHOT
 release.useAutomaticVersion=true
+#kapt.incremental.apt=false

--- a/jersey-uri-builder/src/test/kotlin/com/sourceforgery/jersey/uribuilder/JerseyUriBuilderTest.kt
+++ b/jersey-uri-builder/src/test/kotlin/com/sourceforgery/jersey/uribuilder/JerseyUriBuilderTest.kt
@@ -12,4 +12,12 @@ class JerseyUriBuilderTest {
             .build()
         assertEquals(URI("https://www.google.com/ping?sitemap=https%3A%2F%2Fexample.com%2Fquery%3Ftest%3Dbar"), uri)
     }
+
+    @Test
+    fun `test path encoding`() {
+        val uri = JerseyUriBuilder(URI("https://www.google.com/"))
+            .path("{0}")
+            .build("https://example.com/query?test=bar")
+        assertEquals(URI("https://www.google.com/https:%2F%2Fexample.com%2Fquery%3Ftest=bar"), uri)
+    }
 }

--- a/tachikoma-database-api/build.gradle.kts
+++ b/tachikoma-database-api/build.gradle.kts
@@ -1,14 +1,17 @@
 import io.ebean.gradle.EnhancePluginExtension
 applyKotlin()
 apply(plugin = "io.ebean")
+// apply(plugin = "kotlin-kapt")
 
 dependencies {
     implementation(project(":tachikoma-internal-api"))
 
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
 
+//    add("kapt", "io.ebean:kotlin-querybean-generator:$querybeanVersion")
+
     implementation("io.ebean:ebean:$ebeanVersion")
-    implementation("io.ebean:ebean-querybean:$querybeanVersion")
+//    implementation("io.ebean:ebean-querybean:$querybeanVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
 }
 

--- a/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/dao/EmailDAO.kt
+++ b/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/dao/EmailDAO.kt
@@ -1,14 +1,14 @@
 package com.sourceforgery.tachikoma.database.dao
 
 import com.sourceforgery.tachikoma.database.objects.EmailDBO
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
 import com.sourceforgery.tachikoma.identifiers.EmailId
-import com.sourceforgery.tachikoma.identifiers.MessageId
 
 interface EmailDAO {
     fun fetchEmailData(emailMessageId: EmailId): EmailDBO?
     fun fetchEmailData(emailMessageIds: List<EmailId>): List<EmailDBO>
     fun save(emailDBO: EmailDBO)
     fun getByEmailId(emailId: EmailId): EmailDBO?
-    fun getByMessageId(messageId: MessageId): EmailDBO?
+    fun getByAutoMailId(autoMailId: AutoMailId): EmailDBO?
     fun getByQueueId(queueId: String): EmailDBO?
 }

--- a/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/objects/EmailDBO.kt
+++ b/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/objects/EmailDBO.kt
@@ -2,6 +2,7 @@ package com.sourceforgery.tachikoma.database.objects
 
 import com.sourceforgery.tachikoma.common.Email
 import com.sourceforgery.tachikoma.common.NamedEmail
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
 import com.sourceforgery.tachikoma.identifiers.EmailId
 import com.sourceforgery.tachikoma.identifiers.MessageId
 import io.ebean.annotation.DbJsonB
@@ -21,6 +22,10 @@ constructor(
     val recipient: Email,
     @Column
     val recipientName: String,
+    @Column(unique = true)
+    // Automatic handling mail id
+    // Used as e.g. "unsub-[autoMailId]" and "bounce-[autoMailId]"
+    val autoMailId: AutoMailId,
     @ManyToOne(cascade = [CascadeType.ALL])
     val transaction: EmailSendTransactionDBO,
     @Column(unique = true)
@@ -44,6 +49,7 @@ constructor(
         recipient: NamedEmail,
         transaction: EmailSendTransactionDBO,
         messageId: MessageId,
+        autoMailId: AutoMailId,
         mtaQueueId: String? = null,
         metaData: Map<String, String> = emptyMap()
     ) : this(
@@ -51,6 +57,7 @@ constructor(
         recipientName = recipient.name,
         transaction = transaction,
         messageId = messageId,
+        autoMailId = autoMailId,
         mtaQueueId = mtaQueueId,
         metaData = metaData
     )
@@ -58,3 +65,6 @@ constructor(
 
 val EmailDBO.id: EmailId
     get() = EmailId(dbId!!)
+
+val EmailDBO.recipientNamedEmail: NamedEmail
+    get() = NamedEmail(recipient, recipientName)

--- a/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/objects/EmailStatusEventDBO.kt
+++ b/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/objects/EmailStatusEventDBO.kt
@@ -4,6 +4,7 @@ import com.sourceforgery.tachikoma.common.EmailStatus
 import com.sourceforgery.tachikoma.identifiers.EmailStatusId
 import io.ebean.annotation.CreatedTimestamp
 import io.ebean.annotation.DbJson
+import io.ebean.annotation.Index
 import io.ebean.bean.EntityBean
 import java.time.Instant
 import javax.persistence.CascadeType
@@ -21,6 +22,7 @@ import javax.persistence.Transient
 @Entity
 class EmailStatusEventDBO(
     @Column
+    @Index
     val emailStatus: EmailStatus,
     @ManyToOne(cascade = [CascadeType.ALL])
     val email: EmailDBO,

--- a/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/objects/scalars/AutoMailIdScalarType.kt
+++ b/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/objects/scalars/AutoMailIdScalarType.kt
@@ -1,0 +1,19 @@
+package com.sourceforgery.tachikoma.database.objects.scalars
+
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
+import io.ebean.config.ScalarTypeConverter
+
+@Suppress("unused")
+class AutoMailIdScalarType : ScalarTypeConverter<AutoMailId, String> {
+    override fun getNullValue(): AutoMailId? {
+        return null
+    }
+
+    override fun wrapValue(autoMailId: String): AutoMailId {
+        return AutoMailId(autoMailId)
+    }
+
+    override fun unwrapValue(messageId: AutoMailId): String {
+        return messageId.autoMailId
+    }
+}

--- a/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/DatabaseBinder.kt
+++ b/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/DatabaseBinder.kt
@@ -32,6 +32,7 @@ import com.sourceforgery.tachikoma.database.server.PostgresqlDataSourceProvider
 import com.sourceforgery.tachikoma.database.upgrades.DatabaseUpgrade
 import com.sourceforgery.tachikoma.database.upgrades.Version1
 import com.sourceforgery.tachikoma.database.upgrades.Version10
+import com.sourceforgery.tachikoma.database.upgrades.Version11
 import com.sourceforgery.tachikoma.database.upgrades.Version2
 import com.sourceforgery.tachikoma.database.upgrades.Version3
 import com.sourceforgery.tachikoma.database.upgrades.Version4
@@ -124,7 +125,8 @@ class DatabaseBinder : AbstractBinder() {
             Version7::class.java,
             Version8::class.java,
             Version9::class.java,
-            Version10::class.java
+            Version10::class.java,
+            Version11::class.java
         )
         var idx = 0
         for (databaseUpgrade in databaseUpgrades) {

--- a/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/database/dao/EmailDAOImpl.kt
+++ b/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/database/dao/EmailDAOImpl.kt
@@ -1,8 +1,8 @@
 package com.sourceforgery.tachikoma.database.dao
 
 import com.sourceforgery.tachikoma.database.objects.EmailDBO
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
 import com.sourceforgery.tachikoma.identifiers.EmailId
-import com.sourceforgery.tachikoma.identifiers.MessageId
 import io.ebean.EbeanServer
 import javax.inject.Inject
 
@@ -26,12 +26,11 @@ private constructor(
     override fun getByEmailId(emailId: EmailId) =
         ebeanServer.find(EmailDBO::class.java, emailId.emailId)
 
-    override fun getByMessageId(messageId: MessageId): EmailDBO? {
-        return ebeanServer.find(EmailDBO::class.java)
+    override fun getByAutoMailId(autoMailId: AutoMailId) =
+        ebeanServer.find(EmailDBO::class.java)
             .where()
-            .eq("messageId", messageId.messageId)
+            .eq("autoMailId", autoMailId.autoMailId)
             .findOne()
-    }
 
     override fun getByQueueId(queueId: String) =
         ebeanServer.find(EmailDBO::class.java)

--- a/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/database/upgrades/Version10.kt
+++ b/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/database/upgrades/Version10.kt
@@ -13,7 +13,7 @@ class Version10 : DatabaseUpgrade {
             ALTER TABLE e_email_status ADD CONSTRAINT ck_e_email_status_email_status CHECK ( email_status in (0, 1, 2, 3, 4, 5, 6, 7));
         """.trimIndent()
 
-        DdlRunner(false, "create-all.sql")
+        DdlRunner(false, javaClass.simpleName)
             .runAll(content, connection)
         return -10
     }

--- a/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/database/upgrades/Version11.kt
+++ b/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/database/upgrades/Version11.kt
@@ -1,0 +1,23 @@
+package com.sourceforgery.tachikoma.database.upgrades
+
+import io.ebean.migration.ddl.DdlRunner
+import java.sql.Connection
+import org.intellij.lang.annotations.Language
+
+class Version11 : DatabaseUpgrade {
+    override fun run(connection: Connection): Int {
+        @Language("PostgreSQL")
+        val content = """
+            ALTER TABLE e_email ADD COLUMN auto_mail_id VARCHAR(255);
+            UPDATE e_email SET auto_mail_id = message_id WHERE TRUE;
+            ALTER TABLE e_email ALTER COLUMN auto_mail_id SET NOT NULL;
+            CREATE UNIQUE INDEX uq_e_email_auto_mail_id ON e_email (auto_mail_id);
+            
+            CREATE INDEX ix_e_email_status_email_status ON e_email_status (email_status);
+        """.trimIndent()
+
+        DdlRunner(false, javaClass.simpleName)
+            .runAll(content, connection)
+        return -11
+    }
+}

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/MailDeliveryService.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/MailDeliveryService.kt
@@ -390,7 +390,9 @@ private constructor(
         message.addHeader("Return-Path", bounceReturnPathEmail.address)
         // TODO Abuse-email should be system-wide config parameter
         message.addHeader("X-Report-Abuse", "Please forward a copy of this message, including all headers, to abuse@${fromEmail.domain}")
-        val abuseUrl = JerseyUriBuilder(trackingConfig.baseUrl).paths("abuse", messageId.messageId).build()
+        val abuseUrl = JerseyUriBuilder(trackingConfig.baseUrl)
+            .paths("abuse/{0}")
+            .build(messageId.messageId)
         message.addHeader("X-Report-Abuse", "You can also report abuse here: $abuseUrl")
         message.addHeader("X-Tachikoma-User", accountId.accountId.toString())
     }
@@ -404,8 +406,8 @@ private constructor(
         val unsubscribeUrl = unsubscribeDecoderImpl.createUrl(unsubscribeData)
 
         return JerseyUriBuilder(trackingConfig.baseUrl)
-            .paths("unsubscribe", unsubscribeUrl)
-            .build()
+            .paths("unsubscribe/{0}")
+            .build(unsubscribeUrl)
     }
 
     @TestOnly
@@ -417,8 +419,8 @@ private constructor(
         val unsubscribeUrl = unsubscribeDecoderImpl.createUrl(unsubscribeData)
 
         return JerseyUriBuilder(trackingConfig.baseUrl)
-            .paths("unsubscribe", unsubscribeUrl)
-            .build()
+            .paths("unsubscribe/{0}")
+            .build(unsubscribeUrl)
     }
 
     @TestOnly
@@ -430,8 +432,8 @@ private constructor(
         val trackingUrl = trackingDecoderImpl.createUrl(trackingData)
 
         return JerseyUriBuilder(trackingConfig.baseUrl)
-            .paths("c", trackingUrl)
-            .build()
+            .paths("c/{0}")
+            .build(trackingUrl)
     }
 
     private fun replaceLinks(doc: Document, emailId: EmailId, unsubscribeUri: URI) {
@@ -457,8 +459,8 @@ private constructor(
         val trackingUrl = trackingDecoderImpl.createUrl(trackingData)
 
         val trackingUri = JerseyUriBuilder(trackingConfig.baseUrl)
-            .paths("t", trackingUrl)
-            .build()
+            .paths("t/{0}")
+            .build(trackingUrl)
 
         val trackingPixel = Element("img")
         trackingPixel.attr("src", trackingUri.toString())

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/MailDeliveryService.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/MailDeliveryService.kt
@@ -18,6 +18,7 @@ import com.sourceforgery.tachikoma.database.dao.IncomingEmailDAO
 import com.sourceforgery.tachikoma.database.objects.EmailDBO
 import com.sourceforgery.tachikoma.database.objects.EmailSendTransactionDBO
 import com.sourceforgery.tachikoma.database.objects.id
+import com.sourceforgery.tachikoma.database.objects.recipientNamedEmail
 import com.sourceforgery.tachikoma.database.server.DBObjectMapper
 import com.sourceforgery.tachikoma.exceptions.InvalidOrInsufficientCredentialsException
 import com.sourceforgery.tachikoma.grpc.frontend.emptyToNull
@@ -36,10 +37,10 @@ import com.sourceforgery.tachikoma.grpc.frontend.tracking.UrlTrackingData
 import com.sourceforgery.tachikoma.grpc.frontend.unsubscribe.UnsubscribeData
 import com.sourceforgery.tachikoma.identifiers.AccountId
 import com.sourceforgery.tachikoma.identifiers.AuthenticationId
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
 import com.sourceforgery.tachikoma.identifiers.EmailId
 import com.sourceforgery.tachikoma.identifiers.IncomingEmailId
 import com.sourceforgery.tachikoma.identifiers.MailDomain
-import com.sourceforgery.tachikoma.identifiers.MessageId
 import com.sourceforgery.tachikoma.identifiers.MessageIdFactory
 import com.sourceforgery.tachikoma.maildelivery.getPlainText
 import com.sourceforgery.tachikoma.mq.JobMessageFactory
@@ -47,6 +48,7 @@ import com.sourceforgery.tachikoma.mq.MQSender
 import com.sourceforgery.tachikoma.mq.MQSequenceFactory
 import com.sourceforgery.tachikoma.tracking.TrackingConfig
 import com.sourceforgery.tachikoma.tracking.TrackingDecoderImpl
+import com.sourceforgery.tachikoma.unsubscribe.UnsubscribeConfig
 import com.sourceforgery.tachikoma.unsubscribe.UnsubscribeDecoderImpl
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
@@ -79,6 +81,7 @@ class MailDeliveryService
 @Inject
 private constructor(
     private val trackingConfig: TrackingConfig,
+    private val unsubscribeConfig: UnsubscribeConfig,
     private val dbObjectMapper: DBObjectMapper,
     private val emailDAO: EmailDAO,
     private val emailSendTransactionDAO: EmailSendTransactionDAO,
@@ -97,8 +100,7 @@ private constructor(
     fun sendEmail(
         request: OutgoingEmail,
         responseObserver: StreamObserver<EmailQueueStatus>,
-        authenticationId: AuthenticationId,
-        sender: AccountId
+        authenticationId: AuthenticationId
     ) {
         val auth = authenticationDAO.getActiveById(authenticationId)!!
         val fromEmail = request.from.toNamedEmail().address
@@ -157,30 +159,31 @@ private constructor(
                 val messageId = messageIdFactory.createMessageId(
                     domain = fromEmail.domain
                 )
+                val unsubscribeDomainOverride = unsubscribeConfig.unsubscribeDomainOverride
+                val autoMailId = if (unsubscribeDomainOverride == null) {
+                    AutoMailId("$messageId")
+                } else {
+                    AutoMailId("${messageId.localPart}@$unsubscribeDomainOverride")
+                }
+
                 val emailDBO = EmailDBO(
                     recipient = recipientEmail,
                     transaction = transaction,
                     messageId = messageId,
-                    metaData = recipient.metadataMap
+                    metaData = recipient.metadataMap,
+                    autoMailId = autoMailId
                 )
                 emailDAO.save(emailDBO)
 
                 val pair = when (request.bodyCase) {
                     OutgoingEmail.BodyCase.STATIC -> getStaticBody(
                         request = request,
-                        emailId = emailDBO.id,
-                        messageId = messageId,
-                        fromEmail = fromEmail,
-                        sender = sender,
-                        recipient = recipient
+                        emailDBO = emailDBO
                     )
                     OutgoingEmail.BodyCase.TEMPLATE -> getTemplateBody(
                         request = request,
                         recipient = recipient,
-                        emailId = emailDBO.id,
-                        messageId = messageId,
-                        fromEmail = fromEmail,
-                        sender = sender
+                        emailDBO = emailDBO
                     )
                     else -> throw StatusRuntimeException(Status.INVALID_ARGUMENT)
                 }
@@ -211,10 +214,7 @@ private constructor(
     private fun getTemplateBody(
         request: OutgoingEmail,
         recipient: EmailRecipient,
-        emailId: EmailId,
-        messageId: MessageId,
-        fromEmail: Email,
-        sender: AccountId
+        emailDBO: EmailDBO
     ): Pair<String, String> {
         val template = request.template
         if (template.htmlTemplate.isBlank() && template.plaintextTemplate.isBlank()) {
@@ -240,21 +240,13 @@ private constructor(
             htmlBody = htmlBody.emptyToNull(),
             plaintextBody = plaintextBody.emptyToNull(),
             subject = subject,
-            emailId = emailId,
-            messageId = messageId,
-            fromEmail = fromEmail,
-            sender = sender,
-            recipient = recipient
+            emailDBO = emailDBO
         )
     }
 
     private fun getStaticBody(
         request: OutgoingEmail,
-        emailId: EmailId,
-        messageId: MessageId,
-        fromEmail: Email,
-        sender: AccountId,
-        recipient: EmailRecipient
+        emailDBO: EmailDBO
     ): Pair<String, String> {
         val static = request.static
         val htmlBody = static.htmlBody.emptyToNull()
@@ -265,11 +257,7 @@ private constructor(
             htmlBody = htmlBody,
             plaintextBody = plaintextBody,
             subject = static.subject,
-            emailId = emailId,
-            messageId = messageId,
-            fromEmail = fromEmail,
-            sender = sender,
-            recipient = recipient
+            emailDBO = emailDBO
         )
     }
 
@@ -299,11 +287,7 @@ private constructor(
         htmlBody: String?,
         plaintextBody: String?,
         subject: String,
-        emailId: EmailId,
-        messageId: MessageId,
-        fromEmail: Email,
-        sender: AccountId,
-        recipient: EmailRecipient
+        emailDBO: EmailDBO
     ): String {
         if (htmlBody == null && plaintextBody == null) {
             throw IllegalArgumentException("Needs at least one of plaintext or html")
@@ -313,7 +297,7 @@ private constructor(
         val message = MimeMessage(session)
         message.setFrom(request.from.toNamedEmail().toAddress())
         message.setSubject(subject, "UTF-8")
-        message.setRecipients(Message.RecipientType.TO, arrayOf(recipient.toAddress()))
+        message.setRecipients(Message.RecipientType.TO, arrayOf(emailDBO.recipientNamedEmail.toAddress()))
 
         if (request.replyTo.email.isNotBlank()) {
             val replyToMailDomain = request.replyTo.toEmail().domain.mailDomain
@@ -324,8 +308,12 @@ private constructor(
             message.replyTo = arrayOf(InternetAddress(request.replyTo.email))
         }
 
-        val unsubscribeUri = createUnsubscribeOneClickPostLink(emailId, request.unsubscribeRedirectUri)
-        addListAndAbuseHeaders(message, messageId, fromEmail, sender, unsubscribeUri)
+        val unsubscribeUri = createUnsubscribeOneClickPostLink(emailDBO.id, request.unsubscribeRedirectUri)
+        addListAndAbuseHeaders(
+            message = message,
+            emailDBO = emailDBO,
+            unsubscribeUri = unsubscribeUri
+        )
 
         for ((key, value) in request.headersMap) {
             message.addHeader(key, value)
@@ -340,8 +328,8 @@ private constructor(
                     .prettyPrint(false)
             }
 
-        replaceLinks(htmlDoc, emailId, unsubscribeUri)
-        injectTrackingPixel(htmlDoc, emailId)
+        replaceLinks(htmlDoc, emailDBO.id, unsubscribeUri)
+        injectTrackingPixel(htmlDoc, emailDBO.id)
 
         val plaintextPart = MimeBodyPart()
         val plainText = getPlainText(htmlDoc)
@@ -366,7 +354,7 @@ private constructor(
 
         message.setContent(multipart)
         message.saveChanges()
-        message.setHeader("Message-ID", "<${messageId.messageId}>")
+        message.setHeader("Message-ID", "<${emailDBO.messageId}>")
 
         val result = ByteArrayOutputStream()
         message.writeTo(result)
@@ -377,24 +365,23 @@ private constructor(
             )
     }
 
-    private fun addListAndAbuseHeaders(message: MimeMessage, messageId: MessageId, fromEmail: Email, accountId: AccountId, unsubscribeUri: URI) {
+    private fun addListAndAbuseHeaders(message: MimeMessage, emailDBO: EmailDBO, unsubscribeUri: URI) {
         // TODO Headers to set:
         // List-Help (IMPORTANT): <https://support.google.com/a/example.com/bin/topic.py?topic=25838>, <mailto:debug+help@example.com>
 
-        val unsubscribeEmail = Email("unsub-$messageId")
-        val bounceReturnPathEmail = Email("bounce-$messageId")
-
+        val unsubscribeEmail = Email("unsub-${emailDBO.autoMailId}")
+        val bounceReturnPathEmail = Email("bounce-${emailDBO.autoMailId}")
         // MUST have a valid DomainKeys Identified Mail (DKIM) signature that covers at least the List-Unsubscribe and List-Unsubscribe-Post headers
         message.addHeader("List-Unsubscribe-Post", "List-Unsubscribe=One-Click")
         message.addHeader("List-Unsubscribe", "<mailto:$unsubscribeEmail>, <$unsubscribeUri>")
         message.addHeader("Return-Path", bounceReturnPathEmail.address)
         // TODO Abuse-email should be system-wide config parameter
-        message.addHeader("X-Report-Abuse", "Please forward a copy of this message, including all headers, to abuse@${fromEmail.domain}")
+        message.addHeader("X-Report-Abuse", "Please forward a copy of this message, including all headers, to abuse@${emailDBO.transaction.fromEmail.domain}")
         val abuseUrl = JerseyUriBuilder(trackingConfig.baseUrl)
             .paths("abuse/{0}")
-            .build(messageId.messageId)
+            .build(emailDBO.autoMailId.autoMailId)
         message.addHeader("X-Report-Abuse", "You can also report abuse here: $abuseUrl")
-        message.addHeader("X-Tachikoma-User", accountId.accountId.toString())
+        message.addHeader("X-Tachikoma-User", emailDBO.transaction.authentication.id.toString())
     }
 
     @TestOnly
@@ -504,6 +491,3 @@ private constructor(
 
 fun NamedEmail.toAddress(): InternetAddress =
     InternetAddress(address.address, name)
-
-fun EmailRecipient.toAddress(): InternetAddress =
-    InternetAddress(namedEmail.email, namedEmail.name)

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/MailDeliveryServiceGrpcImpl.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/MailDeliveryServiceGrpcImpl.kt
@@ -39,8 +39,7 @@ private constructor(
             mailDeliveryService.sendEmail(
                 request = request,
                 responseObserver = responseObserver,
-                authenticationId = authentication.authenticationId,
-                sender = authentication.accountId
+                authenticationId = authentication.authenticationId
             )
             responseObserver.onCompleted()
         } catch (e: Exception) {

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/mta/MTAEmailQueueService.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/mta/MTAEmailQueueService.kt
@@ -13,9 +13,9 @@ import com.sourceforgery.tachikoma.database.objects.EmailStatusEventDBO
 import com.sourceforgery.tachikoma.database.objects.IncomingEmailDBO
 import com.sourceforgery.tachikoma.database.objects.StatusEventMetaData
 import com.sourceforgery.tachikoma.database.objects.id
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
 import com.sourceforgery.tachikoma.identifiers.EmailId
 import com.sourceforgery.tachikoma.identifiers.MailDomain
-import com.sourceforgery.tachikoma.identifiers.MessageId
 import com.sourceforgery.tachikoma.mq.DeliveryNotificationMessage
 import com.sourceforgery.tachikoma.mq.IncomingEmailNotificationMessage
 import com.sourceforgery.tachikoma.mq.MQSender
@@ -188,8 +188,8 @@ private constructor(
 
     private fun handleHardBounce(recipientAddress: Email): Pair<AccountDBO, IncomingEmailType>? {
         return if (recipientAddress.address.startsWith("bounce-")) {
-            val messageId = MessageId(recipientAddress.address.substringAfter('-'))
-            emailDAO.getByMessageId(messageId)
+            val autoMailId = AutoMailId(recipientAddress.address.substringAfter('-'))
+            emailDAO.getByAutoMailId(autoMailId)
                 ?.let { email ->
                     val emailStatusEventDBO = EmailStatusEventDBO(
                         email = email,
@@ -214,8 +214,8 @@ private constructor(
 
     private fun handleUnsubscribe(recipientAddress: Email): Pair<AccountDBO, IncomingEmailType>? {
         return if (recipientAddress.address.startsWith("unsub-")) {
-            val messageId = MessageId(recipientAddress.address.substringAfter('-'))
-            emailDAO.getByMessageId(messageId)
+            val autoMailId = AutoMailId(recipientAddress.address.substringAfter('-'))
+            emailDAO.getByAutoMailId(autoMailId)
                 ?.let { email ->
                     val emailStatusEventDBO = EmailStatusEventDBO(
                         email = email,

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/unsubscribe/UnsubscribeConfig.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/unsubscribe/UnsubscribeConfig.kt
@@ -1,0 +1,16 @@
+package com.sourceforgery.tachikoma.unsubscribe
+
+import com.sourceforgery.tachikoma.identifiers.MailDomain
+
+interface UnsubscribeConfig {
+    /**
+     * Used to override the domain in the from address with another domain
+     * so that unsubscribe emails and bounce emails will get bounced
+     * to a tachikoma-connected mail server.
+     *
+     * E.g. sending emails from password-reset@company.com but only receiving
+     * emails to tachikoma on the domain *@tachikoma.company.com.
+     * Setting this to *@tachikoma.company.com would make email unsubscribes work.
+     */
+    val unsubscribeDomainOverride: MailDomain?
+}

--- a/tachikoma-internal-api/src/main/kotlin/com/sourceforgery/tachikoma/identifiers/AutoMailId.kt
+++ b/tachikoma-internal-api/src/main/kotlin/com/sourceforgery/tachikoma/identifiers/AutoMailId.kt
@@ -1,0 +1,13 @@
+package com.sourceforgery.tachikoma.identifiers
+
+// Will be of format "<uuid>@${mailDomain}"
+data class AutoMailId(val autoMailId: String) {
+    // Don't change as it's used in templates
+    override fun toString() = autoMailId
+
+    val localPart
+        get() = autoMailId.substringBefore('@')
+
+    val mailDomain
+        get() = MailDomain(autoMailId.substringAfter('@'))
+}

--- a/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/DAOHelper.kt
+++ b/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/DAOHelper.kt
@@ -13,6 +13,7 @@ import com.sourceforgery.tachikoma.database.objects.EmailStatusEventDBO
 import com.sourceforgery.tachikoma.database.objects.StatusEventMetaData
 import com.sourceforgery.tachikoma.database.server.DBObjectMapper
 import com.sourceforgery.tachikoma.grpc.frontend.maildelivery.OutgoingEmail
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
 import com.sourceforgery.tachikoma.identifiers.MailDomain
 import com.sourceforgery.tachikoma.identifiers.MessageId
 import io.ebean.EbeanServer
@@ -67,7 +68,8 @@ private constructor(
                 metaData = emptyMap(),
                 tags = emptyList()
             ),
-            messageId = MessageId(UUID.randomUUID().toString()),
+            messageId = MessageId("${UUID.randomUUID()}@example.com"),
+            autoMailId = AutoMailId("${UUID.randomUUID()}@example.net"),
             mtaQueueId = null,
             metaData = emptyMap()
         )

--- a/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/TestBinder.kt
+++ b/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/TestBinder.kt
@@ -23,6 +23,7 @@ import com.sourceforgery.tachikoma.mta.MTAEmailQueueService
 import com.sourceforgery.tachikoma.tracking.TrackingConfig
 import com.sourceforgery.tachikoma.tracking.TrackingDecoder
 import com.sourceforgery.tachikoma.tracking.TrackingDecoderImpl
+import com.sourceforgery.tachikoma.unsubscribe.UnsubscribeConfig
 import com.sourceforgery.tachikoma.unsubscribe.UnsubscribeDecoder
 import com.sourceforgery.tachikoma.unsubscribe.UnsubscribeDecoderImpl
 import java.net.URI
@@ -47,11 +48,13 @@ class TestBinder(
     }
 
     override fun configure() {
-        bind(object : TrackingConfig {
+        bind(object : TrackingConfig, UnsubscribeConfig {
             override val linkSignKey = "lk,;sxjdfljkdskljhnfgdskjlhfrjhkl;fdsflijkfgdsjlkfdslkjfjklsd".toByteArray()
             override val baseUrl: URI = URI.create("https://localhost/")
+            override val unsubscribeDomainOverride = MailDomain("example.net")
         })
             .to(TrackingConfig::class.java)
+            .to(UnsubscribeConfig::class.java)
 
         bindAsContract(PerThreadContext::class.java)
             .to(PerThread::class.java)

--- a/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/database/dao/BlockedEmailDAOSpec.kt
+++ b/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/database/dao/BlockedEmailDAOSpec.kt
@@ -15,6 +15,7 @@ import com.sourceforgery.tachikoma.database.objects.EmailStatusEventDBO
 import com.sourceforgery.tachikoma.database.objects.StatusEventMetaData
 import com.sourceforgery.tachikoma.database.server.DBObjectMapper
 import com.sourceforgery.tachikoma.grpc.frontend.maildelivery.OutgoingEmail
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
 import com.sourceforgery.tachikoma.identifiers.MailDomain
 import com.sourceforgery.tachikoma.identifiers.MessageId
 import java.util.Collections
@@ -70,7 +71,8 @@ internal class BlockedEmailDAOSpec : Spek({
             recipient = recipient,
             recipientName = "Mr. Recipient",
             transaction = emailSendTransaction,
-            messageId = MessageId("1023"),
+            messageId = MessageId("1023@example.com"),
+            autoMailId = AutoMailId("1023@example.net"),
             mtaQueueId = null,
             metaData = emptyMap()
         )

--- a/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/database/dao/EmailDAOSpec.kt
+++ b/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/database/dao/EmailDAOSpec.kt
@@ -12,6 +12,7 @@ import com.sourceforgery.tachikoma.database.objects.EmailSendTransactionDBO
 import com.sourceforgery.tachikoma.database.objects.id
 import com.sourceforgery.tachikoma.database.server.DBObjectMapper
 import com.sourceforgery.tachikoma.grpc.frontend.maildelivery.OutgoingEmail
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
 import com.sourceforgery.tachikoma.identifiers.MailDomain
 import com.sourceforgery.tachikoma.identifiers.MessageId
 import kotlin.test.assertNotNull
@@ -65,7 +66,8 @@ internal class EmailDAOSpec : Spek({
             recipient = recipient,
             recipientName = "Mr. Recipient",
             transaction = emailSendTransaction,
-            messageId = MessageId("1023"),
+            messageId = MessageId("1023@example.com"),
+            autoMailId = AutoMailId("1023@example.net"),
             mtaQueueId = null,
             metaData = emptyMap()
         )

--- a/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/maildelivery/MailDeliveryServiceSpec.kt
+++ b/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/maildelivery/MailDeliveryServiceSpec.kt
@@ -66,7 +66,6 @@ class MailDeliveryServiceSpec : Spek({
             val responseObserver = QueueStreamObserver<EmailQueueStatus>()
             mailDeliveryService.sendEmail(
                 request = email,
-                sender = authentication.account.id,
                 responseObserver = responseObserver,
                 authenticationId = authentication.id
             )

--- a/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/mta/MTAEmailQueueServiceSpec.kt
+++ b/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/mta/MTAEmailQueueServiceSpec.kt
@@ -17,6 +17,7 @@ import com.sourceforgery.tachikoma.database.objects.id
 import com.sourceforgery.tachikoma.grpc.QueueStreamObserver
 import com.sourceforgery.tachikoma.hk2.getValue
 import com.sourceforgery.tachikoma.hk2.hk2
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
 import com.sourceforgery.tachikoma.identifiers.MailDomain
 import com.sourceforgery.tachikoma.identifiers.MessageId
 import com.sourceforgery.tachikoma.mq.MQSenderMock
@@ -88,7 +89,8 @@ class MTAEmailQueueServiceSpec : Spek({
             email = EmailDBO(
                 recipient = Email("foo@example.net"),
                 recipientName = "Nobody",
-                messageId = MessageId("sdjklfjklsdfkl@example.net"),
+                messageId = MessageId("sdjklfjklsdfkl@example.com"),
+                autoMailId = AutoMailId("sdjklfjklsdfkl@example.net"),
                 metaData = emptyMap(),
                 transaction = EmailSendTransactionDBO(
                     jsonRequest = JsonNodeFactory.instance.objectNode(),

--- a/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/rest/unsubscribe/UnsubscribeRestTest.kt
+++ b/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/rest/unsubscribe/UnsubscribeRestTest.kt
@@ -24,6 +24,7 @@ import com.sourceforgery.tachikoma.grpc.frontend.toAuthenticationId
 import com.sourceforgery.tachikoma.grpc.frontend.toFrontendRole
 import com.sourceforgery.tachikoma.hk2.getValue
 import com.sourceforgery.tachikoma.hk2.hk2
+import com.sourceforgery.tachikoma.identifiers.AutoMailId
 import com.sourceforgery.tachikoma.identifiers.MailDomain
 import com.sourceforgery.tachikoma.identifiers.MessageId
 import com.sourceforgery.tachikoma.maildelivery.impl.MailDeliveryService
@@ -186,7 +187,8 @@ class UnsubscribeRestTest {
         emailDBO = EmailDBO(
             recipient = NamedEmail(blockedEmail, "Foobar"),
             transaction = transaction,
-            messageId = MessageId("2-id")
+            messageId = MessageId("2-id@example.com"),
+            autoMailId = AutoMailId("2-id@example.net")
         )
         ebeanServer.save(emailDBO)
 

--- a/tachikoma-it/src/test/resources/attachment_email.txt
+++ b/tachikoma-it/src/test/resources/attachment_email.txt
@@ -1,4 +1,4 @@
-Return-Path: bounce-not-really-random1@example.com
+Return-Path: bounce-not-really-random1@example.net
 Date: XXXXX
 From: Valid From Email <from@example.com>
 To: Valid Email <foo@example.com>
@@ -8,10 +8,10 @@ MIME-Version: 1.0
 Content-Type: multipart/alternative; 
 	boundary="XXXXXX"
 List-Unsubscribe-Post: List-Unsubscribe=One-Click
-List-Unsubscribe: <mailto:unsub-not-really-random1@example.com>, <https://localhost/unsubscribe/qgYGqgYDCNoEsgYUTvZ8D-6pcCGve1lszODcxOS5HZo>
+List-Unsubscribe: <mailto:unsub-not-really-random1@example.net>, <https://localhost/unsubscribe/qgYGqgYDCNoEsgYUTvZ8D-6pcCGve1lszODcxOS5HZo>
 X-Report-Abuse: Please forward a copy of this message, including all headers, to abuse@example.com
-X-Report-Abuse: You can also report abuse here: https://localhost/abuse/not-really-random1@example.com
-X-Tachikoma-User: 1
+X-Report-Abuse: You can also report abuse here: https://localhost/abuse/not-really-random1@example.net
+X-Tachikoma-User: 101
 
 --XXXXXX
 Content-Type: text/plain; charset=utf-8

--- a/tachikoma-startup/src/main/kotlin/com/sourceforgery/tachikoma/config/Configuration.kt
+++ b/tachikoma-startup/src/main/kotlin/com/sourceforgery/tachikoma/config/Configuration.kt
@@ -3,9 +3,17 @@ package com.sourceforgery.tachikoma.config
 import com.sourceforgery.tachikoma.identifiers.MailDomain
 import com.sourceforgery.tachikoma.mq.MqConfig
 import com.sourceforgery.tachikoma.tracking.TrackingConfig
+import com.sourceforgery.tachikoma.unsubscribe.UnsubscribeConfig
 import java.net.URI
 
-internal class Configuration : DatabaseConfig, TrackingConfig, MqConfig, WebServerConfig, DebugConfig, WebtokenAuthConfig {
+internal class Configuration :
+    DatabaseConfig,
+    DebugConfig,
+    MqConfig,
+    TrackingConfig,
+    UnsubscribeConfig,
+    WebServerConfig,
+    WebtokenAuthConfig {
     override val databaseEncryptionKey by readEncryptionConfig("DATABASE_ENCRYPTION_KEY")
     override val mqUrl by readConfig("MQ_URL", URI("amqp://guest:guest@localhost/tachikoma"))
     override val sendDebugData: Boolean by readConfig("SEND_DEBUG_DATA", true)
@@ -17,4 +25,5 @@ internal class Configuration : DatabaseConfig, TrackingConfig, MqConfig, WebServ
     override val sslCertChainFile by readConfig("SSL_CERT_CHAIN_FILE", "")
     override val sslCertKeyFile by readConfig("SSL_CERT_KEY_FILE", "")
     override val mailDomains by readListConfig("MAIL_DOMAINS", listOf(MailDomain("example.com")))
+    override val unsubscribeDomainOverride by readConfig("UNSUBSCRIBE_DOMAIN_OVERRIDE", null as MailDomain?)
 }


### PR DESCRIPTION
Used to override the domain in the from address
so that unsubscribe emails and bounce emails will get bounced
to a tachikoma-connected mail server.

E.g. sending emails from password-reset@company.com but only receiving
emails to tachikoma on the domain *@tachikoma.company.com.
Setting this to *@tachikoma.company.com would make email unsubscribes work.