### PR TITLE
Feature/email metrics in notification

### DIFF
--- a/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/objects/StatusEventMetaData.kt
+++ b/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/objects/StatusEventMetaData.kt
@@ -5,5 +5,6 @@ constructor(
     val mtaStatusCode: String? = null,
     val mtaDiagnosticText: String? = null,
     val ipAddress: String? = null,
-    val trackingLink: String? = null
+    val trackingLink: String? = null,
+    val userAgent: String? = null
 )

--- a/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/admin/emailstatusevent/emailstatusevent.proto
+++ b/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/admin/emailstatusevent/emailstatusevent.proto
@@ -31,7 +31,7 @@ message GetEmailStatusEventsFilter {
     // Whether to include tracking data in the response or not . Like all bools, defaults to false.
     bool include_tracking_data = 105;
 
-    // Whether to include email metrics in the response or not. If true all clicks and opens per email is included in the respons
+    // Whether to include email metrics in the response or not. If true all clicks and opens per email is included in the response
     bool include_metrics_data = 106;
 }
 

--- a/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/admin/emailstatusevent/emailstatusevent.proto
+++ b/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/admin/emailstatusevent/emailstatusevent.proto
@@ -30,6 +30,9 @@ message GetEmailStatusEventsFilter {
 
     // Whether to include tracking data in the response or not . Like all bools, defaults to false.
     bool include_tracking_data = 105;
+
+    // Whether to include email metrics in the response or not. If true all clicks and opens per email is included in the respons
+    bool include_metrics_data = 106;
 }
 
 // Event types available to filter on

--- a/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
+++ b/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
@@ -42,7 +42,6 @@ message EmailNotification {
     MessageId message_id = 105;
     EmailAddress sender_email_address = 106;
     // Metrics for clicks and opens of an email
-    EmailMetrics email_metrics = 107;
     oneof notification {
         SoftBouncedEvent soft_bounced_event = 201;
         HardBouncedEvent hard_bounced_event = 202;
@@ -61,6 +60,12 @@ message EmailNotification {
 
     // Optional depending on parameters for the rpc method
     string subject = 401;
+
+    // Optional depending on parameters for the rpc method
+    oneof metrics {
+        EmailMetrics email_metrics = 501;
+        google.protobuf.Empty no_metrics_data = 502;
+    }
 }
 
 message EmailMetrics {

--- a/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
+++ b/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
@@ -41,7 +41,6 @@ message EmailNotification {
     google.protobuf.Timestamp timestamp = 104;
     MessageId message_id = 105;
     EmailAddress sender_email_address = 106;
-    // Metrics for clicks and opens of an email
     oneof notification {
         SoftBouncedEvent soft_bounced_event = 201;
         HardBouncedEvent hard_bounced_event = 202;
@@ -52,6 +51,7 @@ message EmailNotification {
         UnsubscribedEvent unsubscribed_event = 207;
         SpamEvent spam_event = 208;
     }
+    // Email tracking data
     // Optional depending on parameters for the rpc method
     oneof tracking {
         SentEmailTrackingData email_tracking_data = 301;
@@ -61,6 +61,7 @@ message EmailNotification {
     // Optional depending on parameters for the rpc method
     string subject = 401;
 
+    // Metrics for clicks and opens of an email
     // Optional depending on parameters for the rpc method
     oneof metrics {
         EmailMetrics email_metrics = 501;

--- a/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
+++ b/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
@@ -126,6 +126,8 @@ message QueuedEvent {
 message OpenedEvent {
     // IP address that downloaded the tracking pixel
     string ip_address = 101;
+    // Opened by client with user agent
+    string user_agent = 102;
 }
 
 // Message has been clicked
@@ -134,6 +136,8 @@ message ClickedEvent {
     string ip_address = 101;
     // Url clicked in the email
     string clicked_url = 102;
+    // Clicked by client with user agent
+    string user_agent = 103;
 }
 
 // Message has caused receiver to unsubscribe

--- a/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
+++ b/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
@@ -79,7 +79,7 @@ message EmailMetricsOpenData {
     string ip_address = 101;
     // User agent for the opening email
     string user_agent = 102;
-    // Opened time stamp
+    // Opened timestamp
     google.protobuf.Timestamp timestamp = 103;
 }
 

--- a/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
+++ b/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
@@ -90,7 +90,7 @@ message EmailMetricsClickData {
     string clicked_url = 102;
     // User agent for the click
     string user_agent = 103;
-    // Clicked time stamp
+    // Clicked timestamp
     google.protobuf.Timestamp timestamp = 104;
 }
 

--- a/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
+++ b/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
@@ -64,8 +64,8 @@ message EmailNotification {
     // Metrics for clicks and opens of an email
     // Optional depending on parameters for the rpc method
     oneof metrics {
-        EmailMetrics email_metrics = 501;
-        google.protobuf.Empty no_metrics_data = 502;
+        google.protobuf.Empty no_metrics_data = 501;
+        EmailMetrics email_metrics = 502;
     }
 }
 

--- a/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
+++ b/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/common.proto
@@ -41,6 +41,8 @@ message EmailNotification {
     google.protobuf.Timestamp timestamp = 104;
     MessageId message_id = 105;
     EmailAddress sender_email_address = 106;
+    // Metrics for clicks and opens of an email
+    EmailMetrics email_metrics = 107;
     oneof notification {
         SoftBouncedEvent soft_bounced_event = 201;
         HardBouncedEvent hard_bounced_event = 202;
@@ -59,6 +61,31 @@ message EmailNotification {
 
     // Optional depending on parameters for the rpc method
     string subject = 401;
+}
+
+message EmailMetrics {
+    repeated EmailMetricsOpenData opens = 101;
+    repeated EmailMetricsClickData clicks = 102;
+}
+
+message EmailMetricsOpenData {
+    // IP address that downloaded the tracking pixel
+    string ip_address = 101;
+    // User agent for the opening email
+    string user_agent = 102;
+    // Opened time stamp
+    google.protobuf.Timestamp timestamp = 103;
+}
+
+message EmailMetricsClickData {
+    // Ip address that clicked the link
+    string ip_address = 101;
+    // Url clicked in the email
+    string clicked_url = 102;
+    // User agent for the click
+    string user_agent = 103;
+    // Clicked time stamp
+    google.protobuf.Timestamp timestamp = 104;
 }
 
 // Tracking data structure for a single email

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/emailstatusevent/EmailStatusEventService.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/emailstatusevent/EmailStatusEventService.kt
@@ -57,9 +57,9 @@ private constructor(
 
         emailStatusEventDAO.getEvents(
             accountId = authenticationDBO.account.id,
-            instant = request.newerThan?.toInstant(),
-            recipientEmail = request.recipientEmail?.toEmail(),
-            fromEmail = request.fromEmail?.toEmail(),
+            instant = request.newerThan.toInstant(),
+            recipientEmail = request.recipientEmail.toEmail(),
+            fromEmail = request.fromEmail.toEmail(),
             events = events
         )
             .forEach {

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/emailstatusevent/EmailStatusEventService.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/emailstatusevent/EmailStatusEventService.kt
@@ -86,12 +86,22 @@ private constructor(
         return when (emailStatusEventDBO.emailStatus) {
             EmailStatus.OPENED -> {
                 val ipAddress = emailStatusEventDBO.metaData.ipAddress ?: ""
-                builder.setOpenedEvent(OpenedEvent.newBuilder().setIpAddress(ipAddress).build())
+                builder.setOpenedEvent(
+                    OpenedEvent.newBuilder()
+                        .setIpAddress(ipAddress)
+                        .setUserAgent(emailStatusEventDBO.metaData.userAgent ?: "")
+                        .build()
+                )
             }
 
             EmailStatus.CLICKED -> {
                 val ipAddress = emailStatusEventDBO.metaData.ipAddress ?: ""
-                builder.setClickedEvent(ClickedEvent.newBuilder().setIpAddress(ipAddress).build())
+                builder.setClickedEvent(
+                    ClickedEvent.newBuilder()
+                        .setIpAddress(ipAddress)
+                        .setUserAgent(emailStatusEventDBO.metaData.userAgent ?: "")
+                        .build()
+                )
             }
             EmailStatus.HARD_BOUNCED -> {
                 builder.setHardBouncedEvent(HardBouncedEvent.getDefaultInstance())

--- a/tachikoma-mq/src/main/kotlin/com/sourceforgery/tachikoma/mq/jobs/Job.kt
+++ b/tachikoma-mq/src/main/kotlin/com/sourceforgery/tachikoma/mq/jobs/Job.kt
@@ -8,6 +8,7 @@ class JobFactory
 private constructor() {
     fun getJobClass(jobMessage: JobMessage): Class<out Job> {
         val jobDataCase = jobMessage.jobDataCase
+        @Suppress("WHEN_ENUM_CAN_BE_NULL_IN_JAVA")
         return when (jobDataCase) {
             JobMessage.JobDataCase.JOBDATA_NOT_SET -> throw IllegalArgumentException("Jobdata not set")
             JobMessage.JobDataCase.SEND_EMAIL_JOB -> SendEmailJob::class.java

--- a/tachikoma-rest/src/main/kotlin/com/sourceforgery/tachikoma/rest/tracking/TrackingRest.kt
+++ b/tachikoma-rest/src/main/kotlin/com/sourceforgery/tachikoma/rest/tracking/TrackingRest.kt
@@ -1,9 +1,12 @@
 package com.sourceforgery.tachikoma.rest.tracking
 
+import com.linecorp.armeria.common.HttpHeaderNames
 import com.linecorp.armeria.common.HttpResponse
 import com.linecorp.armeria.common.HttpStatus
 import com.linecorp.armeria.common.MediaType
+import com.linecorp.armeria.server.annotation.Default
 import com.linecorp.armeria.server.annotation.Get
+import com.linecorp.armeria.server.annotation.Header
 import com.linecorp.armeria.server.annotation.Param
 import com.linecorp.armeria.server.annotation.Produces
 import com.sourceforgery.tachikoma.common.EmailStatus
@@ -37,15 +40,18 @@ private constructor(
 ) : RestService {
     @Get("regex:^/t/(?<trackingData>.*)}")
     @Produces("image/gif")
-    fun trackOpen(@Param("trackingData") trackingDataString: String): HttpResponse {
+    fun trackOpen(
+        @Param("trackingData") trackingDataString: String,
+        @Header("User-Agent") @Default("") userAgent: String
+    ): HttpResponse {
         return if (trackingDataString.endsWith("/1")) {
-            actuallyTrackOpen(trackingDataString.removeSuffix("/1"))
+            actuallyTrackOpen(trackingDataString.removeSuffix("/1"), userAgent)
         } else {
             RestUtil.httpRedirect("/t/$trackingDataString/1")
         }
     }
 
-    private fun actuallyTrackOpen(trackingDataString: String): HttpResponse {
+    private fun actuallyTrackOpen(trackingDataString: String, userAgent: String): HttpResponse {
         try {
             val trackingData = trackingDecoder.decodeTrackingData(trackingDataString)
 
@@ -54,7 +60,8 @@ private constructor(
                 emailStatus = EmailStatus.OPENED,
                 email = email,
                 metaData = StatusEventMetaData(
-                    ipAddress = remoteIP.remoteAddress
+                    ipAddress = remoteIP.remoteAddress,
+                    userAgent = userAgent
                 )
             )
             emailStatusEventDAO.save(emailStatusEvent)
@@ -73,15 +80,18 @@ private constructor(
 
     @Get("regex:^/c/(?<trackingData>.*)")
     @Produces("text/html")
-    fun trackClick(@Param("trackingData") trackingDataString: String): HttpResponse {
+    fun trackClick(
+        @Param("trackingData") trackingDataString: String,
+        @Header("User-Agent") @Default("") userAgent: String
+    ): HttpResponse {
         return if (trackingDataString.endsWith("/1")) {
-            actuallyTrackClick(trackingDataString.removeSuffix("/1"))
+            actuallyTrackClick(trackingDataString.removeSuffix("/1"), userAgent)
         } else {
             RestUtil.httpRedirect("/c/$trackingDataString/1")
         }
     }
 
-    private fun actuallyTrackClick(trackingDataString: String): HttpResponse {
+    private fun actuallyTrackClick(trackingDataString: String, userAgent: String): HttpResponse {
         try {
             val trackingData = trackingDecoder.decodeTrackingData(trackingDataString)
 
@@ -91,7 +101,8 @@ private constructor(
                 email = email,
                 metaData = StatusEventMetaData(
                     ipAddress = remoteIP.remoteAddress,
-                    trackingLink = trackingData.redirectUrl
+                    trackingLink = trackingData.redirectUrl,
+                    userAgent = userAgent
                 ))
             emailStatusEventDAO.save(emailStatusEvent)
 

--- a/tachikoma-rest/src/main/kotlin/com/sourceforgery/tachikoma/rest/tracking/TrackingRest.kt
+++ b/tachikoma-rest/src/main/kotlin/com/sourceforgery/tachikoma/rest/tracking/TrackingRest.kt
@@ -1,6 +1,5 @@
 package com.sourceforgery.tachikoma.rest.tracking
 
-import com.linecorp.armeria.common.HttpHeaderNames
 import com.linecorp.armeria.common.HttpResponse
 import com.linecorp.armeria.common.HttpStatus
 import com.linecorp.armeria.common.MediaType

--- a/tachikoma-rest/src/main/kotlin/com/sourceforgery/tachikoma/rest/tracking/TrackingRest.kt
+++ b/tachikoma-rest/src/main/kotlin/com/sourceforgery/tachikoma/rest/tracking/TrackingRest.kt
@@ -68,7 +68,10 @@ private constructor(
             val notificationMessageBuilder = DeliveryNotificationMessage.newBuilder()
                 .setCreationTimestamp(emailStatusEvent.dateCreated!!.toTimestamp())
                 .setEmailMessageId(email.id.emailId)
-                .setMessageOpened(MessageOpened.newBuilder().setIpAddress(remoteIP.remoteAddress))
+                .setMessageOpened(
+                    MessageOpened.newBuilder()
+                        .setIpAddress(remoteIP.remoteAddress)
+                )
             mqSender.queueDeliveryNotification(email.transaction.authentication.account.id, notificationMessageBuilder.build())
         } catch (e: Exception) {
             LOGGER.warn { "Failed to track invalid link $trackingDataString with error ${e.message}" }


### PR DESCRIPTION
Extended the notification events for emails to include prior click / open events. 
Also added User-Agent for click and open events. 

This feature is to mimic how both Mandrill and SendInBlue pass email notification back to the calling server. 