### PR TITLE
Reconnect rabbitmq on failure

### DIFF
--- a/tachikoma-mq/build.gradle.kts
+++ b/tachikoma-mq/build.gradle.kts
@@ -4,7 +4,7 @@ dependencies {
     implementation(project(":tachikoma-internal-api"))
 //    implementation(project(":tachikoma-common"))
 
-    implementation("com.rabbitmq:amqp-client:5.8.0")
+    implementation("com.rabbitmq:amqp-client:5.9.0")
     implementation("org.apache.logging.log4j:log4j-api-kotlin:1.0.0")
     implementation("org.glassfish.hk2:hk2-api:$hk2Version")
     implementation("org.glassfish.hk2.external:jakarta.inject:$hk2Version")

--- a/tachikoma-mq/src/main/kotlin/com/sourceforgery/tachikoma/mq/ConsumerFactoryImpl.kt
+++ b/tachikoma-mq/src/main/kotlin/com/sourceforgery/tachikoma/mq/ConsumerFactoryImpl.kt
@@ -1,6 +1,7 @@
 package com.sourceforgery.tachikoma.mq
 
 import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.MoreExecutors
 import com.google.common.util.concurrent.SettableFuture
 import com.rabbitmq.client.AMQP
 import com.rabbitmq.client.Channel
@@ -19,7 +20,6 @@ import com.sourceforgery.tachikoma.identifiers.AuthenticationId
 import com.sourceforgery.tachikoma.identifiers.MailDomain
 import java.time.Clock
 import java.time.Duration
-import java.util.concurrent.Executors
 import javax.annotation.PreDestroy
 import javax.inject.Inject
 import org.apache.logging.log4j.kotlin.logger
@@ -35,7 +35,6 @@ private constructor(
     private var thread = 0
     private val connection: Connection
     private val sendChannel: Channel
-    private val closeExecutor = Executors.newSingleThreadExecutor()
 
     init {
         val connectionFactory = ConnectionFactory()
@@ -44,6 +43,10 @@ private constructor(
         connectionFactory.setUri(mqConfig.mqUrl)
         connection = connectionFactory.newConnection()
         sendChannel = connection.createChannel()
+
+        createQueue(FAILED_INCOMING_EMAIL_NOTIFICATIONS)
+        createQueue(FAILED_DELIVERY_NOTIFICATIONS)
+        createQueue(FAILED_OUTGOING_EMAILS)
 
         for (messageQueue in JobMessageQueue.values()) {
             createQueue(messageQueue)
@@ -59,8 +62,7 @@ private constructor(
         connection.close()
     }
 
-    private inner class WorkerThread
-    internal constructor(
+    private inner class WorkerThread(
         runnable: Runnable,
         private val threadName: String
     ) : Thread(runnable, threadName) {
@@ -68,7 +70,7 @@ private constructor(
         @Synchronized
         override fun start() {
             if (threadName == name) {
-                LOGGER.info { "Starting thread: " + name }
+                LOGGER.info { "Starting thread: $name" }
             }
             super.start()
         }
@@ -133,27 +135,31 @@ private constructor(
             .createChannel()!!
 
         val future = SettableFuture.create<Void>()
-        future.addListener(Runnable {
-            LOGGER.info("Closing channel")
-            channel.close()
-        }, closeExecutor)
+        future.addListener(
+            Runnable {
+                LOGGER.info("Closing channel")
+                try {
+                    channel.close()
+                } catch (ignored: Exception) {
+                    // 'tis ok
+                }
+            },
+            MoreExecutors.directExecutor()
+        )
         val consumer = object : DefaultConsumer(channel) {
             override fun handleDelivery(consumerTag: String, envelope: Envelope, properties: AMQP.BasicProperties, body: ByteArray) {
                 LOGGER.debug { "Processing message, message queue name: ${messageQueue.name}, consumer tag: $consumerTag, body md5: ${HmacUtil.calculateMd5(body)}" }
-                var handledResult = false
+                var success = false
                 try {
                     val parsedMessage = messageQueue.parser(body)
                     hK2RequestContext.runInScope(ctx) { callback(parsedMessage) }
                     channel.basicAck(envelope.deliveryTag, false)
-                    handledResult = true
+                    success = true
                 } catch (e: Exception) {
                     LOGGER.error(e) { "Got exception, message queue name: ${messageQueue.name}, consumer tag: $consumerTag, body md5: ${HmacUtil.calculateMd5(body)}" }
-                    future.setException(e)
-                    handledResult = true
                 } finally {
-                    if (!handledResult) {
-                        // Will be NACK'd by closing channel when Future completes
-                        future.cancel(true)
+                    if (!success) {
+                        channel.basicNack(envelope.deliveryTag, false, false)
                     }
                 }
             }
@@ -188,7 +194,7 @@ private constructor(
     }
 
     override fun listenForJobs(callback: (JobMessage) -> Unit): ListenableFuture<Void> {
-        return listenOnQueue(JobMessageQueue.JOBS) { it ->
+        return listenOnQueue(JobMessageQueue.JOBS) {
             val messageQueue = getRequeueQueueByRequestedExecutionTime(it)
             if (messageQueue == null) {
                 // Message has waited long enough

--- a/tachikoma-mq/src/main/kotlin/com/sourceforgery/tachikoma/mq/ConsumerFactoryImpl.kt
+++ b/tachikoma-mq/src/main/kotlin/com/sourceforgery/tachikoma/mq/ConsumerFactoryImpl.kt
@@ -10,6 +10,7 @@ import com.rabbitmq.client.ConnectionFactory
 import com.rabbitmq.client.DefaultConsumer
 import com.rabbitmq.client.Envelope
 import com.rabbitmq.client.MessageProperties
+import com.rabbitmq.client.impl.ChannelN
 import com.sourceforgery.tachikoma.common.HmacUtil
 import com.sourceforgery.tachikoma.common.timestamp
 import com.sourceforgery.tachikoma.common.toInstant
@@ -165,7 +166,13 @@ private constructor(
             }
         }
         channel.basicConsume(messageQueue.name, false, consumer)
-        channel.addShutdownListener { future.cancel(false) }
+        channel.addShutdownListener {
+            if (it.isInitiatedByApplication) {
+                future.cancel(false)
+            } else {
+                (channel as ChannelN).processShutdownSignal(it, true, true)
+            }
+        }
         return future
     }
 

--- a/tachikoma-mq/src/main/kotlin/com/sourceforgery/tachikoma/mq/MessageQueue.kt
+++ b/tachikoma-mq/src/main/kotlin/com/sourceforgery/tachikoma/mq/MessageQueue.kt
@@ -9,7 +9,8 @@ enum class JobMessageQueue(
     override val maxLength: Int? = null,
     override val nextDestination: MessageQueue<JobMessage>? = null
 ) : MessageQueue<JobMessage> {
-    JOBS,
+    FAILED_JOBS,
+    JOBS(nextDestination = FAILED_JOBS),
     JOBS_30_SEC(delay = Duration.ofSeconds(30), nextDestination = JOBS),
     JOBS_1_MIN(delay = Duration.ofMinutes(1), nextDestination = JOBS),
     JOBS_2_MIN(delay = Duration.ofMinutes(2), nextDestination = JOBS),
@@ -28,7 +29,17 @@ enum class JobMessageQueue(
     override val parser: (ByteArray) -> JobMessage = JobMessage::parseFrom
 
     init {
-        assert((delay == Duration.ZERO) == (nextDestination == null))
+        assert(delay == Duration.ZERO || nextDestination != null)
+    }
+}
+
+internal val FAILED_OUTGOING_EMAILS = object : MessageQueue<OutgoingEmailMessage> {
+    override val delay = Duration.ZERO
+    override val maxLength = null
+    override val nextDestination = null
+    override val name = "FAILED_OUTGOING_EMAILS"
+    override val parser: (ByteArray) -> OutgoingEmailMessage = {
+        error("No parser for this")
     }
 }
 
@@ -36,13 +47,19 @@ class OutgoingEmailsMessageQueue(
     mailDomain: MailDomain
 ) : MessageQueue<OutgoingEmailMessage> {
     override val name = "outgoing.$mailDomain"
-    override val maxLength: Int? = null
-    override val delay: Duration = Duration.ZERO
-    override val nextDestination: MessageQueue<OutgoingEmailMessage>? = null
+    override val maxLength = null
+    override val delay = Duration.ZERO
+    override val nextDestination = FAILED_OUTGOING_EMAILS
     override val parser: (ByteArray) -> OutgoingEmailMessage = OutgoingEmailMessage::parseFrom
+}
 
-    init {
-        assert((delay == Duration.ZERO) == (nextDestination == null))
+internal val FAILED_DELIVERY_NOTIFICATIONS = object : MessageQueue<DeliveryNotificationMessage> {
+    override val delay = Duration.ZERO
+    override val maxLength = null
+    override val nextDestination = null
+    override val name = "FAILED_DELIVERY_NOTIFICATIONS"
+    override val parser: (ByteArray) -> DeliveryNotificationMessage = {
+        error("No parser for this")
     }
 }
 
@@ -51,12 +68,18 @@ class DeliveryNotificationMessageQueue(
     override val maxLength: Int? = null
 ) : MessageQueue<DeliveryNotificationMessage> {
     override val name = "deliverynotifications.$authenticationId"
-    override val delay: Duration = Duration.ZERO
-    override val nextDestination: MessageQueue<DeliveryNotificationMessage>? = null
+    override val delay = Duration.ZERO
+    override val nextDestination = FAILED_DELIVERY_NOTIFICATIONS
     override val parser: (ByteArray) -> DeliveryNotificationMessage = DeliveryNotificationMessage::parseFrom
+}
 
-    init {
-        assert((delay == Duration.ZERO) == (nextDestination == null))
+internal val FAILED_INCOMING_EMAIL_NOTIFICATIONS = object : MessageQueue<IncomingEmailNotificationMessage> {
+    override val delay = Duration.ZERO
+    override val maxLength = null
+    override val nextDestination = null
+    override val name = "FAILED_INCOMING_EMAIL_NOTIFICATIONS"
+    override val parser: (ByteArray) -> IncomingEmailNotificationMessage = {
+        error("No parser for this")
     }
 }
 
@@ -65,11 +88,7 @@ class IncomingEmailNotificationMessageQueue(
     override val maxLength: Int? = null
 ) : MessageQueue<IncomingEmailNotificationMessage> {
     override val name = "incomingemail.$authenticationId"
-    override val delay: Duration = Duration.ZERO
-    override val nextDestination: MessageQueue<IncomingEmailNotificationMessage>? = null
+    override val delay = Duration.ZERO
+    override val nextDestination = FAILED_INCOMING_EMAIL_NOTIFICATIONS
     override val parser: (ByteArray) -> IncomingEmailNotificationMessage = IncomingEmailNotificationMessage::parseFrom
-
-    init {
-        assert((delay == Duration.ZERO) == (nextDestination == null))
-    }
 }

--- a/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/Main.kt
+++ b/tachikoma-webserver/src/main/kotlin/com/sourceforgery/tachikoma/webserver/Main.kt
@@ -1,11 +1,9 @@
 package com.sourceforgery.tachikoma.webserver
 
-import com.linecorp.armeria.common.HttpMethod
 import com.linecorp.armeria.common.SessionProtocol
 import com.linecorp.armeria.common.grpc.GrpcSerializationFormats
 import com.linecorp.armeria.server.HttpService
 import com.linecorp.armeria.server.Server
-import com.linecorp.armeria.server.cors.CorsService
 import com.linecorp.armeria.server.grpc.GrpcService
 import com.linecorp.armeria.server.healthcheck.HealthCheckService
 import com.linecorp.armeria.server.logging.AccessLogWriter
@@ -46,11 +44,7 @@ class WebServerStarter(
     private fun startServerInBackground(): CompletableFuture<Void> {
         val requestScoped: HttpRequestScopedDecorator by serviceLocator
 
-        val healthService = CorsService
-            .builderForAnyOrigin()
-            .allowCredentials()
-            .allowRequestMethods(HttpMethod.GET)
-            .build(HealthCheckService.of())
+        val healthService = HealthCheckService.of()
 
         // Order matters!
         val serverBuilder = Server.builder()


### PR DESCRIPTION
When Rabbitmq is restarted, the client does not reconnect properly.

This fixes that AND adds special queues that the messages will end up on
when a job fails for any reason