### PR TITLE
Parse headers in incoming emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,10 +143,17 @@ To revert to the default post fix behaviour remove the following line from the f
 
 `postconf -e "bounce_service_name=discard"`
 
+Every _incoming_ email with multiple receivers will be split up into
+several identical emails.
+
+```postconf -e "lmtp_destination_recipient_limit=1"```
+
+
 The default retry behaviour has also been altered for deferred email to retry in 14400s (4 hours) instead of 4000s (just over an hour) and it will keep trying
 for three days instead of five. To revert to the default behaviour remove these lines 
 
 ```
 postconf -e "maximal_backoff_time=14400s"
 postconf -e "maximal_queue_lifetime=3d"
+postconf -e "bounce_queue_lifetime=3d"
 ```

--- a/README.md
+++ b/README.md
@@ -53,8 +53,12 @@ the webserver (for e.g. gRPC) at port 8070.
 
 To start the docker (with the Postfix email server), first create a file with the format
 ```properties
+# The url including the backend authentication to the tachikoma webserver
 TACHIKOMA_URL=http://example.com:xxxxxxxxxxxxxxxxxxxx@172.17.0.1:8070/
+# If the mailserver is MX for the domain above (example.com)
 MAIL_DOMAIN_MX=false
+# The hostname of the smtp server. Used both when sending email and receiving them
+TACHIKOMA_HOSTNAME=smtpserver.example.com
 ```
 
 run
@@ -99,12 +103,14 @@ Environment=name=tachikoma-postfix
 Environment=configDir=/opt/example.com
 Environment=mailDomain=EXAMPLE.COM
 Environment=backendApiKey=XXXXXXXXXXXXXXXXX
+Environment=smtpHostname=SMTP.EXAMPLE.COM
 Environment=webserverHost=TACHIKOMA-SERVER.EXAMPLE.COM
 Environment=image=sourceforgery/tachikoma-postfix:VERSION
 
 ExecStartPre=/usr/bin/docker pull ${image}
 ExecStart=/usr/bin/docker run --rm=true -p 25:25 --name=${name} \
   -e MAIL_DOMAIN_MX=false \
+  -e TACHIKOMA_HOSTNAME=${smtpHostname}
   -e TACHIKOMA_URL=https://${mailDomain}:${backendApiKey}@${webserverHost} \
   -v ${configDir}/domainkeys:/etc/opendkim/domainkeys \
   -v ${configDir}/postfix:/var/spool/postfix \
@@ -140,4 +146,7 @@ To revert to the default post fix behaviour remove the following line from the f
 The default retry behaviour has also been altered for deferred email to retry in 14400s (4 hours) instead of 4000s (just over an hour) and it will keep trying
 for three days instead of five. To revert to the default behaviour remove these lines 
 
-`postconf -e "maximal_backoff_time=14400s" postconf -e "maximal_queue_lifetime=3d"` 
+```
+postconf -e "maximal_backoff_time=14400s"
+postconf -e "maximal_queue_lifetime=3d"
+```

--- a/buildSrc/src/main/kotlin/com/sourceforgery/tachikoma/buildsrc/DockerSetup.kt
+++ b/buildSrc/src/main/kotlin/com/sourceforgery/tachikoma/buildsrc/DockerSetup.kt
@@ -41,5 +41,5 @@ fun Project.dockerSetup() {
 
     val dockerTask by tasks.registering() {}
 
-    tasks["assemble"].dependsOn(dockerTask)
+    tasks["build"].dependsOn(dockerTask)
 }

--- a/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/objects/IncomingEmailDBO.kt
+++ b/tachikoma-database-api/src/main/kotlin/com/sourceforgery/tachikoma/database/objects/IncomingEmailDBO.kt
@@ -1,7 +1,9 @@
 package com.sourceforgery.tachikoma.database.objects
 
 import com.sourceforgery.tachikoma.common.Email
+import com.sourceforgery.tachikoma.common.NamedEmail
 import com.sourceforgery.tachikoma.identifiers.IncomingEmailId
+import io.ebean.annotation.DbJsonB
 import javax.persistence.Column
 import javax.persistence.Entity
 import javax.persistence.ManyToOne
@@ -11,13 +13,21 @@ import javax.persistence.Table
 @Entity
 class IncomingEmailDBO(
     @Column
-    val fromEmail: Email,
+    val mailFrom: Email,
     @Column
-    val fromName: String,
+    val recipient: Email,
+
+    // Temporarily writable properties
+    @DbJsonB
     @Column
-    val receiverEmail: Email,
+    var fromEmails: List<NamedEmail>,
+    @DbJsonB
     @Column
-    val receiverName: String,
+    var replyToEmails: List<NamedEmail>,
+    @DbJsonB
+    @Column
+    var toEmails: List<NamedEmail>,
+
     @Column
     val body: ByteArray,
     @ManyToOne

--- a/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/DatabaseBinder.kt
+++ b/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/DatabaseBinder.kt
@@ -30,6 +30,7 @@ import com.sourceforgery.tachikoma.database.server.PostgresqlDataSourceProvider
 import com.sourceforgery.tachikoma.database.upgrades.Version1
 import com.sourceforgery.tachikoma.database.upgrades.Version10
 import com.sourceforgery.tachikoma.database.upgrades.Version11
+import com.sourceforgery.tachikoma.database.upgrades.Version12
 import com.sourceforgery.tachikoma.database.upgrades.Version2
 import com.sourceforgery.tachikoma.database.upgrades.Version3
 import com.sourceforgery.tachikoma.database.upgrades.Version4
@@ -86,4 +87,5 @@ private val databaseUpgradesModule = DI.Module("databaseUpgrades") {
     bind<Version9>() with provider { Version9() }
     bind<Version10>() with provider { Version10() }
     bind<Version11>() with provider { Version11() }
+    bind<Version12>() with provider { Version12(di) }
 }

--- a/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/database/hooks/EbeanHook.kt
+++ b/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/database/hooks/EbeanHook.kt
@@ -1,7 +1,7 @@
 package com.sourceforgery.tachikoma.database.hooks
 
-import io.ebean.EbeanServer
+import io.ebean.Database
 
-abstract class EbeanHook {
-    open fun postStart(ebeanServer: EbeanServer) {}
+interface EbeanHook {
+    fun postStart(database: Database)
 }

--- a/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/database/upgrades/Version12.kt
+++ b/tachikoma-database/src/main/kotlin/com/sourceforgery/tachikoma/database/upgrades/Version12.kt
@@ -1,0 +1,57 @@
+package com.sourceforgery.tachikoma.database.upgrades
+
+import com.sourceforgery.tachikoma.common.ExtractEmailMetadata
+import com.sourceforgery.tachikoma.database.hooks.EbeanHook
+import com.sourceforgery.tachikoma.database.objects.query.QIncomingEmailDBO
+import io.ebean.Database
+import io.ebean.migration.ddl.DdlRunner
+import java.sql.Connection
+import kotlin.math.absoluteValue
+import org.intellij.lang.annotations.Language
+import org.kodein.di.DI
+import org.kodein.di.DIAware
+import org.kodein.di.instance
+
+class Version12(override val di: DI) : DatabaseUpgrade, EbeanHook, DIAware {
+    override val newVersion: Int = -12
+    private var upgraded = false
+
+    private val extractEmailMetadata: ExtractEmailMetadata by instance()
+
+    override fun run(connection: Connection): Int {
+        @Language("PostgreSQL")
+        val content = """
+            ALTER TABLE e_incoming_email
+            RENAME COLUMN from_email TO mail_from_email;
+            ALTER TABLE e_incoming_email
+                RENAME COLUMN from_name TO mail_from_name;
+            ALTER TABLE e_incoming_email
+                RENAME COLUMN receiver_email TO recipient_email;
+            ALTER TABLE e_incoming_email
+                RENAME COLUMN receiver_name TO recipient_name;
+                
+            ALTER TABLE e_incoming_email
+                ADD COLUMN from_emails jsonb not null default '[]',
+                ADD COLUMN reply_to_emails jsonb not null default '[]',
+                ADD COLUMN to_emails jsonb not null default '[]';
+        """.trimIndent()
+
+        DdlRunner(false, javaClass.simpleName)
+            .runAll(content, connection)
+        upgraded = true
+        return newVersion.absoluteValue
+    }
+
+    override fun postStart(database: Database) {
+        if (upgraded) {
+            QIncomingEmailDBO(database)
+                .findEach {
+                    val emails = extractEmailMetadata.extract(it.body)
+                    it.replyToEmails = emails.replyTo
+                    it.fromEmails = emails.from
+                    it.toEmails = emails.to
+                    database.save(it)
+                }
+        }
+    }
+}

--- a/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/maildelivery/maildelivery.proto
+++ b/tachikoma-frontend-api-proto/src/main/proto/com/sourceforgery/tachikoma/grpc/frontend/maildelivery/maildelivery.proto
@@ -256,14 +256,26 @@ message IncomingEmailAttachment {
     string file_name = 12;
 }
 
-
 // IncomingEmail is an email that is sent to the mail server
 message IncomingEmail {
     IncomingEmailId incoming_email_id = 101;
 
-    NamedEmailAddress from = 201;
-    NamedEmailAddress to = 202;
+    NamedEmailAddress mail_from_old = 201 [deprecated = true];
+    NamedEmailAddress recipient_to_old = 202 [deprecated = true];
+    // Subject of the email
     string subject = 203;
+    // The From address in the headers
+    repeated NamedEmailAddress from = 204;
+    // The To address in the headers
+    repeated NamedEmailAddress to = 205;
+    // The Reply-To in the headers
+    repeated NamedEmailAddress reply_to = 206;
+    // MAIL FROM address. This is the previous email address that the email
+    // passed through, e.g. forwarding email or mailing list
+    EmailAddress mail_from = 207;
+    // RCPT TO To address. This is the email address that
+    // the last server tried
+    EmailAddress recipient_to = 208;
 
     // Optional. It must be explicitly requested.
     // This is the header (including the smtp envelope, but excluding body/attachments)

--- a/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/IncomingEmailService.kt
+++ b/tachikoma-grpc/src/main/kotlin/com/sourceforgery/tachikoma/maildelivery/impl/IncomingEmailService.kt
@@ -53,11 +53,15 @@ class IncomingEmailService(override val di: DI) : DIAware {
             val session = Session.getDefaultInstance(Properties())
             MimeMessage(session, ByteArrayInputStream(body))
         }
+        @Suppress("DEPRECATION")
         return IncomingEmail.newBuilder()
             .setIncomingEmailId(id.toGrpc())
             .setSubject(subject)
-            .setTo(NamedEmail(receiverEmail, receiverName).toGrpc())
-            .setFrom(NamedEmail(fromEmail, fromName).toGrpc())
+            .setMailFromOld(NamedEmail(mailFrom, "").toGrpc())
+            .setRecipientToOld(NamedEmail(recipient, "").toGrpc())
+            .addAllFrom(fromEmails.map { it.toGrpc() })
+            .addAllReplyTo(replyToEmails.map { it.toGrpc() })
+            .addAllTo(toEmails.map { it.toGrpc() })
             .onlyIf(parameters.includeMessageParsedBodies) {
                 includeParsedBodies(parsedMessage)
             }

--- a/tachikoma-internal-api/build.gradle.kts
+++ b/tachikoma-internal-api/build.gradle.kts
@@ -5,6 +5,7 @@ dependencies {
     implementation("com.google.guava:guava:$guavaVersion")
     implementation("com.linecorp.armeria:armeria:$armeriaVersion")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$kotlinCoroutineVersion")
+    implementation("com.sun.mail:javax.mail:$javaxMailVersion")
 
     api(project(":tachikoma-common"))
     api(project(":tachikoma-frontend-api-proto:tachikoma-frontend-api-jvm"))

--- a/tachikoma-internal-api/src/main/kotlin/com/sourceforgery/tachikoma/common/ExtractEmailMetadata.kt
+++ b/tachikoma-internal-api/src/main/kotlin/com/sourceforgery/tachikoma/common/ExtractEmailMetadata.kt
@@ -1,0 +1,36 @@
+package com.sourceforgery.tachikoma.common
+
+import java.io.ByteArrayInputStream
+import java.util.Properties
+import javax.mail.Address
+import javax.mail.Message
+import javax.mail.Session
+import javax.mail.internet.InternetAddress
+import javax.mail.internet.MimeMessage
+import org.kodein.di.DI
+import org.kodein.di.DIAware
+
+class ExtractEmailMetadata(override val di: DI) : DIAware {
+    fun extract(message: ByteArray): EmailMetadata {
+        val mimeMessage = MimeMessage(Session.getDefaultInstance(Properties()), ByteArrayInputStream(message))
+        return EmailMetadata(
+            from = mimeMessage.from.parseNamedEmails(),
+            replyTo = mimeMessage.replyTo.parseNamedEmails(),
+            to = mimeMessage.getRecipients(Message.RecipientType.TO).parseNamedEmails(),
+            cc = mimeMessage.getRecipients(Message.RecipientType.CC).parseNamedEmails()
+        )
+    }
+}
+
+data class EmailMetadata(
+    val from: List<NamedEmail>,
+    val replyTo: List<NamedEmail>,
+    val to: List<NamedEmail>,
+    val cc: List<NamedEmail>
+)
+
+internal fun Array<Address>.parseNamedEmails(): List<NamedEmail> =
+    asSequence()
+        .filterIsInstance<InternetAddress>()
+        .map { NamedEmail(it.address, it.personal) }
+        .toList()

--- a/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/maildelivery/IncomingEmailTest.kt
+++ b/tachikoma-it/src/test/kotlin/com/sourceforgery/tachikoma/maildelivery/IncomingEmailTest.kt
@@ -62,10 +62,11 @@ class IncomingEmailTest : DIAware {
         } returns IncomingEmailDBO(
             body = sample.envelope,
             account = mockk(),
-            fromEmail = from.address,
-            fromName = from.name,
-            receiverEmail = to.address,
-            receiverName = to.name,
+            mailFrom = from.address,
+            recipient = to.address,
+            replyToEmails = emptyList(),
+            toEmails = emptyList(),
+            fromEmails = emptyList(),
             subject = subject
         ).also {
             it.setId(incomingEmailId)
@@ -73,8 +74,6 @@ class IncomingEmailTest : DIAware {
 
         val mess = processIt(incomingEmailId)
         assertEquals(subject, mess.subject)
-        assertEmail(to, mess.to)
-        assertEmail(from, mess.from)
         assertEquals(incomingEmailId.incomingEmailId, mess.incomingEmailId.id)
         assertEquals(1, mess.messageAttachmentsCount)
         assertEquals("", mess.messageHtmlBody)
@@ -99,10 +98,11 @@ class IncomingEmailTest : DIAware {
         } returns IncomingEmailDBO(
             body = sample.envelope,
             account = mockk(),
-            fromEmail = from.address,
-            fromName = from.name,
-            receiverEmail = to.address,
-            receiverName = to.name,
+            mailFrom = from.address,
+            recipient = to.address,
+            replyToEmails = emptyList(),
+            toEmails = emptyList(),
+            fromEmails = emptyList(),
             subject = subject
         ).also {
             it.setId(incomingEmailId)
@@ -110,8 +110,6 @@ class IncomingEmailTest : DIAware {
 
         val mess = processIt(incomingEmailId)
         assertEquals(subject, mess.subject)
-        assertEmail(to, mess.to)
-        assertEmail(from, mess.from)
         assertEquals(incomingEmailId.incomingEmailId, mess.incomingEmailId.id)
         assertEquals(6, mess.messageAttachmentsCount)
         assertEquals(sample.plainText, mess.messageAttachmentsList[0].dataString.homogenize())
@@ -138,10 +136,11 @@ class IncomingEmailTest : DIAware {
         } returns IncomingEmailDBO(
             body = sample.envelope,
             account = mockk(),
-            fromEmail = from.address,
-            fromName = from.name,
-            receiverEmail = to.address,
-            receiverName = to.name,
+            mailFrom = from.address,
+            recipient = to.address,
+            replyToEmails = emptyList(),
+            toEmails = emptyList(),
+            fromEmails = emptyList(),
             subject = subject
         ).also {
             it.setId(incomingEmailId)
@@ -149,8 +148,6 @@ class IncomingEmailTest : DIAware {
 
         val mess = processIt(incomingEmailId)
         assertEquals(subject, mess.subject)
-        assertEmail(to, mess.to)
-        assertEmail(from, mess.from)
         assertEquals(incomingEmailId.incomingEmailId, mess.incomingEmailId.id)
         assertEquals(5, mess.messageAttachmentsCount)
         assertEquals(sample.htmlText, mess.messageAttachmentsList[0].dataString.homogenize())
@@ -176,10 +173,11 @@ class IncomingEmailTest : DIAware {
         } returns IncomingEmailDBO(
             body = sample.envelope,
             account = mockk(),
-            fromEmail = from.address,
-            fromName = from.name,
-            receiverEmail = to.address,
-            receiverName = to.name,
+            mailFrom = from.address,
+            recipient = to.address,
+            replyToEmails = emptyList(),
+            toEmails = emptyList(),
+            fromEmails = emptyList(),
             subject = subject
         ).also {
             it.setId(incomingEmailId)
@@ -187,8 +185,6 @@ class IncomingEmailTest : DIAware {
 
         val mess = processIt(incomingEmailId)
         assertEquals(subject, mess.subject)
-        assertEmail(to, mess.to)
-        assertEmail(from, mess.from)
         assertEquals(incomingEmailId.incomingEmailId, mess.incomingEmailId.id)
         assertEquals(5, mess.messageAttachmentsCount)
         assertEquals(sample.plainText, mess.messageAttachmentsList[0].dataString.homogenize())

--- a/tachikoma-postfix-docker/build.gradle.kts
+++ b/tachikoma-postfix-docker/build.gradle.kts
@@ -6,7 +6,7 @@ val postfixDocker by tasks.registering(se.transmode.gradle.plugins.docker.Docker
     dependsOn(tarTask)
     applicationName = "tachikoma-postfix"
 
-    baseImage = "ubuntu:19.10"
+    baseImage = "ubuntu:20.04"
 
     maintainer = "tachikoma@sourceforgery.com"
 

--- a/tachikoma-postfix-utils/src/main/kotlin/com/sourceforgery/tachikoma/incoming/LMTPServer.kt
+++ b/tachikoma-postfix-utils/src/main/kotlin/com/sourceforgery/tachikoma/incoming/LMTPServer.kt
@@ -35,13 +35,13 @@ class LMTPServer(
                 output.sendLine("250 8BITMIME")
 
                 val from = input
-                    .assertRegex("MAIL FROM: *(.*)")
+                    .assertRegex("MAIL FROM: *<(.*)>")
                     .groupValues[1]
                     .substringBeforeLast(' ')
                 output.sendLine("250 OK")
 
                 val to = input
-                    .assertRegex("RCPT TO: *(.*)")
+                    .assertRegex("RCPT TO: *<(.*)>")
                     .groupValues[1]
                 output.sendLine("250 OK")
 

--- a/tachikoma-postfix-utils/src/main/resources/log4j2.xml
+++ b/tachikoma-postfix-utils/src/main/resources/log4j2.xml
@@ -18,7 +18,7 @@
             <AppenderRef ref="StdOut"/>
         </Root>
         <Logger name="com.sourceforgery.tachikoma" level="trace"/>
-        <Logger name="smtp.incoming.debug" level="trace"/>
+<!--        <Logger name="smtp.incoming.debug" level="trace"/>-->
         <Logger name="smtp.send" level="trace"/>
     </Loggers>
 </Configuration>

--- a/tachikoma-webserver-docker/build.gradle.kts
+++ b/tachikoma-webserver-docker/build.gradle.kts
@@ -8,7 +8,7 @@ val webserverDocker by tasks.registering(se.transmode.gradle.plugins.docker.Dock
 
     applicationName = "tachikoma-webserver"
 
-    baseImage = "ubuntu:19.10"
+    baseImage = "ubuntu:20.04"
     maintainer = "tachikoma@sourceforgery.com"
 
     setEnvironment("DEBIAN_FRONTEND", "noninteractive")


### PR DESCRIPTION
Many changes:

* Upgrade to Ubuntu 20.04 for all docker images
* Change which task docker build is run for
* Add parsing of To, Reply-To and From. Also clean up types after checking rfc's and (more importantly) the ad-hoc standards.